### PR TITLE
Fixes for use in kerberized environments

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.stream.binder.kafka.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.StringUtils;
 
@@ -29,6 +32,8 @@ import org.springframework.util.StringUtils;
 public class KafkaBinderConfigurationProperties {
 
 	private String[] zkNodes = new String[] {"localhost"};
+
+	private Map<String, String> configuration = new HashMap<>();
 
 	private String defaultZkPort = "2181";
 
@@ -71,12 +76,6 @@ public class KafkaBinderConfigurationProperties {
 	private int minPartitionCount = 1;
 
 	private int queueSize = 8192;
-
-	private String consumerGroup;
-
-	public String getConsumerGroup() {
-		return this.consumerGroup;
-	}
 
 	public String getZkConnectionString() {
 		return toConnectionString(this.zkNodes, this.defaultZkPort);
@@ -248,8 +247,11 @@ public class KafkaBinderConfigurationProperties {
 		this.socketBufferSize = socketBufferSize;
 	}
 
-	public void setConsumerGroup(String consumerGroup) {
-		this.consumerGroup = consumerGroup;
+	public Map<String, String> getConfiguration() {
+		return configuration;
 	}
 
+	public void setConfiguration(Map<String, String> configuration) {
+		this.configuration = configuration;
+	}
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -164,7 +164,7 @@ public class KafkaBinderTests
 		KafkaBinderConfigurationProperties configurationProperties = createConfigurationProperties();
 		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, configurationProperties.getKafkaConnectionString());
 		props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-		props.put(ConsumerConfig.GROUP_ID_CONFIG, configurationProperties.getConsumerGroup());
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, "TEST-CONSUMER-GROUP");
 		Deserializer<byte[]> valueDecoder = new ByteArrayDeserializer();
 		Deserializer<byte[]> keyDecoder = new ByteArrayDeserializer();
 


### PR DESCRIPTION
Fixes #10

Use secured Kerberos ZK client
Add common client properties - security properties don't
have to be repeated