### PR TITLE
Configure JAAS settings for Kafka via Spring Boot

### DIFF
--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -215,18 +215,120 @@ spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_SSL
 All the other security properties can be set in a similar manner.
 
 When using Kerberos, follow the instructions in the http://kafka.apache.org/090/documentation.html#security_sasl_clientconfig[reference documentation] for creating and referencing the JAAS configuration.
-At the time of this release, the JAAS, and (optionally) krb5 file locations must be set for Spring Cloud Stream applications by using system properties.
-Here is an example of launching a Spring Cloud Stream application with SASL and Kerberos.
+
+Spring Cloud Stream supports passing JAAS configuration information to the application using a JAAS configuration file and using Spring Boot properties.
+
+===== Using JAAS configuration files
+
+The JAAS, and (optionally) krb5 file locations can be set for Spring Cloud Stream applications by using system properties.
+Here is an example of launching a Spring Cloud Stream application with SASL and Kerberos using a JAAS configuration file:
 
 [source]
 ----
- java -Djava.security.auth.login.config=/path.to/kafka_client_jaas.conf -jar log.jar \\
-   --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \\
-   --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \\
-   --spring.cloud.stream.bindings.input.destination=stream.ticktock \\
+ java -Djava.security.auth.login.config=/path.to/kafka_client_jaas.conf -jar log.jar \
+   --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
+   --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \
+   --spring.cloud.stream.bindings.input.destination=stream.ticktock \
    --spring.cloud.stream.kafka.binder.clientConfiguration.security.protocol=SASL_PLAINTEXT
 ----
 
+===== Using Spring Boot properties
+
+As an alternative to having a JAAS configuration file, Spring Cloud Stream provides a mechanism for setting up the JAAS configuration for Spring Cloud Stream applications using Spring Boot properties.
+
+The following properties can be used for configuring the login context of the Kafka client.
+
+spring.cloud.stream.kafka.binder.jaas.loginModule::
+  The login module name. Not necessary to be set in normal cases.
++
+Default: `com.sun.security.auth.module.Krb5LoginModule`.
+spring.cloud.stream.kafka.binder.jaas.controlFlag::
+  The control flag of the login module.
++
+Default: `required`.
+spring.cloud.stream.kafka.binder.jaas.options::
+  Map with a key/value pair containing the login module options.
++
+Default: Empty map.
+
+If the application also requires access to a secured Zookeeper instance, e.g. if it needs to create and configure topics on the broker, the following properties can be set:
+
+spring.cloud.stream.kafka.binder.zkJaas.loginModule::
+  The login module name. Not necessary to be set in normal cases.
++
+Default: `com.sun.security.auth.module.Krb5LoginModule`.
+spring.cloud.stream.kafka.binder.zkJaas.controlFlag::
+  The control flag of the login module.
++
+Default: `required`.
+spring.cloud.stream.kafka.binder.zkJaas.options::
+  Map with a key/value pair containing the login module options.
++
+Default: Empty map.
+
+Here is an example of launching a Spring Cloud Stream application with SASL and Kerberos using Spring Boot configuration properties:
+
+[source]
+----
+ java -Djava.security.auth.login.config=/path.to/kafka_client_jaas.conf -jar log.jar \
+   --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
+   --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \
+   --spring.cloud.stream.bindings.input.destination=stream.ticktock \
+   --spring.cloud.stream.kafka.binder.clientConfiguration.security.protocol=SASL_PLAINTEXT \
+   --spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true \
+   --spring.cloud.stream.kafka.binder.jaas.options.storeKey=true \
+   --spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab \
+   --spring.cloud.stream.kafka.binder.jaas.options.principal=kafka-client-1@EXAMPLE.COM \
+   --spring.cloud.stream.kafka.binder.zkJaas.options.useKeyTab=true \
+   --spring.cloud.stream.kafka.binder.zkJaas.options.storeKey=true \
+   --spring.cloud.stream.kafka.binder.zkJaas.options.keyTab=/etc/security/keytabs/zk_client.keytab \
+   --spring.cloud.stream.kafka.binder.zkJaas.options.principal=zk-client-1@EXAMPLE.COM
+----
+
+This represents the equivalent of the following JAAS file:
+
+[source]
+----
+KafkaClient {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/security/keytabs/kafka_client.keytab"
+    principal="kafka-client-1@EXAMPLE.COM";
+};
+Client {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/security/keytabs/zk_client.keytab"
+    principal="zk-client-1@EXAMPLE.COM";
+};
+----
+
+If the topics required already exist on the broker, or will be created by an administrator, autocreation can be turned off and only client JAAS properties need to be sent:
+
+[source]
+----
+ java -Djava.security.auth.login.config=/path.to/kafka_client_jaas.conf -jar log.jar \
+   --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
+   --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \
+   --spring.cloud.stream.bindings.input.destination=stream.ticktock \
+   --spring.cloud.stream.kafka.binder.autoCreateTopics=false \
+   --spring.cloud.stream.kafka.binder.clientConfiguration.security.protocol=SASL_PLAINTEXT \
+   --spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true \
+   --spring.cloud.stream.kafka.binder.jaas.options.storeKey=true \
+   --spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab \
+   --spring.cloud.stream.kafka.binder.jaas.options.principal=kafka-client-1@EXAMPLE.COM
+----
+
+As an alternative to setting `spring.cloud.stream.kafka.binder.autoCreateTopics` you can simply remove the broker dependency from the application. See <<exclude-admin-utils>> for details.
+
+[NOTE]
+====
+Do not mix JAAS configuration files and Spring Boot properties in the same application.
+If the `-Djava.security.auth.login.config` system property is already present, Spring Cloud Stream will ignore the Spring Boot properties.
+
+====
 
 [NOTE]
 ====
@@ -272,6 +374,7 @@ The versions above are provided only for the sake of the example.
 For best results, we recommend using the most recent 0.10-compatible versions of the projects.
 ====
 
+[[exclude-admin-utils]]
 ==== Excluding Kafka broker jar from the classpath of the binder based application
 
 The Apache Kafka Binder uses the administrative utilities which are part of the Apache Kafka server library to create and reconfigure topics.

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -229,7 +229,7 @@ Here is an example of launching a Spring Cloud Stream application with SASL and 
    --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
    --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \
    --spring.cloud.stream.bindings.input.destination=stream.ticktock \
-   --spring.cloud.stream.kafka.binder.clientConfiguration.security.protocol=SASL_PLAINTEXT
+   --spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_PLAINTEXT
 ----
 
 ===== Using Spring Boot properties
@@ -270,11 +270,10 @@ Here is an example of launching a Spring Cloud Stream application with SASL and 
 
 [source]
 ----
- java -Djava.security.auth.login.config=/path.to/kafka_client_jaas.conf -jar log.jar \
-   --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
+ java --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
    --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \
    --spring.cloud.stream.bindings.input.destination=stream.ticktock \
-   --spring.cloud.stream.kafka.binder.clientConfiguration.security.protocol=SASL_PLAINTEXT \
+   --spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_PLAINTEXT \
    --spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true \
    --spring.cloud.stream.kafka.binder.jaas.options.storeKey=true \
    --spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab \
@@ -309,12 +308,11 @@ If the topics required already exist on the broker, or will be created by an adm
 
 [source]
 ----
- java -Djava.security.auth.login.config=/path.to/kafka_client_jaas.conf -jar log.jar \
-   --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
+ java --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
    --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \
    --spring.cloud.stream.bindings.input.destination=stream.ticktock \
    --spring.cloud.stream.kafka.binder.autoCreateTopics=false \
-   --spring.cloud.stream.kafka.binder.clientConfiguration.security.protocol=SASL_PLAINTEXT \
+   --spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_PLAINTEXT \
    --spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true \
    --spring.cloud.stream.kafka.binder.jaas.options.storeKey=true \
    --spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab \

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -251,60 +251,7 @@ spring.cloud.stream.kafka.binder.jaas.options::
 +
 Default: Empty map.
 
-If the application also requires access to a secured Zookeeper instance, e.g. if it needs to create and configure topics on the broker, the following properties can be set:
-
-spring.cloud.stream.kafka.binder.zkJaas.loginModule::
-  The login module name. Not necessary to be set in normal cases.
-+
-Default: `com.sun.security.auth.module.Krb5LoginModule`.
-spring.cloud.stream.kafka.binder.zkJaas.controlFlag::
-  The control flag of the login module.
-+
-Default: `required`.
-spring.cloud.stream.kafka.binder.zkJaas.options::
-  Map with a key/value pair containing the login module options.
-+
-Default: Empty map.
-
 Here is an example of launching a Spring Cloud Stream application with SASL and Kerberos using Spring Boot configuration properties:
-
-[source]
-----
- java --spring.cloud.stream.kafka.binder.brokers=secure.server:9092 \
-   --spring.cloud.stream.kafka.binder.zkNodes=secure.zookeeper:2181 \
-   --spring.cloud.stream.bindings.input.destination=stream.ticktock \
-   --spring.cloud.stream.kafka.binder.configuration.security.protocol=SASL_PLAINTEXT \
-   --spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true \
-   --spring.cloud.stream.kafka.binder.jaas.options.storeKey=true \
-   --spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab \
-   --spring.cloud.stream.kafka.binder.jaas.options.principal=kafka-client-1@EXAMPLE.COM \
-   --spring.cloud.stream.kafka.binder.zkJaas.options.useKeyTab=true \
-   --spring.cloud.stream.kafka.binder.zkJaas.options.storeKey=true \
-   --spring.cloud.stream.kafka.binder.zkJaas.options.keyTab=/etc/security/keytabs/zk_client.keytab \
-   --spring.cloud.stream.kafka.binder.zkJaas.options.principal=zk-client-1@EXAMPLE.COM
-----
-
-This represents the equivalent of the following JAAS file:
-
-[source]
-----
-KafkaClient {
-    com.sun.security.auth.module.Krb5LoginModule required
-    useKeyTab=true
-    storeKey=true
-    keyTab="/etc/security/keytabs/kafka_client.keytab"
-    principal="kafka-client-1@EXAMPLE.COM";
-};
-Client {
-    com.sun.security.auth.module.Krb5LoginModule required
-    useKeyTab=true
-    storeKey=true
-    keyTab="/etc/security/keytabs/zk_client.keytab"
-    principal="zk-client-1@EXAMPLE.COM";
-};
-----
-
-If the topics required already exist on the broker, or will be created by an administrator, autocreation can be turned off and only client JAAS properties need to be sent:
 
 [source]
 ----
@@ -319,7 +266,20 @@ If the topics required already exist on the broker, or will be created by an adm
    --spring.cloud.stream.kafka.binder.jaas.options.principal=kafka-client-1@EXAMPLE.COM
 ----
 
-As an alternative to setting `spring.cloud.stream.kafka.binder.autoCreateTopics` you can simply remove the broker dependency from the application. See <<exclude-admin-utils>> for details.
+This represents the equivalent of the following JAAS file:
+
+[source]
+----
+KafkaClient {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/security/keytabs/kafka_client.keytab"
+    principal="kafka-client-1@EXAMPLE.COM";
+};
+----
+
+If the topics required already exist on the broker, or will be created by an administrator, autocreation can be turned off and only client JAAS properties need to be sent. As an alternative to setting `spring.cloud.stream.kafka.binder.autoCreateTopics` you can simply remove the broker dependency from the application. See <<exclude-admin-utils>> for details.
 
 [NOTE]
 ====

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListener.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListener.java
@@ -86,16 +86,6 @@ public class KafkaBinderJaasInitializerListener implements ApplicationListener<C
 										Collections.<String, Object>emptyMap());
 				configurationEntries.put(JaasUtils.LOGIN_CONTEXT_CLIENT,
 						new AppConfigurationEntry[]{ kafkaClientConfigurationEntry });
-				if (binderConfigurationProperties.getZkJaas() != null) {
-					AppConfigurationEntry zkClientConfigurationEntry = new AppConfigurationEntry
-							(binderConfigurationProperties.getZkJaas().getLoginModule(),
-									binderConfigurationProperties.getZkJaas().getControlFlagValue(),
-									binderConfigurationProperties.getZkJaas().getOptions() != null ?
-											binderConfigurationProperties.getZkJaas().getOptions() :
-											Collections.<String, Object>emptyMap());
-					configurationEntries.put(System.getProperty(JaasUtils.ZK_LOGIN_CONTEXT_NAME_KEY, DEFAULT_ZK_LOGIN_CONTEXT_NAME),
-							new AppConfigurationEntry[]{ zkClientConfigurationEntry });
-				}
 				Configuration.setConfiguration(new InternalConfiguration(configurationEntries));
 				// Workaround for a 0.9 client issue where even if the Configuration is set
 				// a system property check is performed.

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -436,7 +436,7 @@ public class KafkaMessageChannelBinder extends
 					"No topic will be created by the binder");
 		}
 		else if (!this.configurationProperties.isAutoCreateTopics()) {
-			this.logger.warn("Auto creation of topics is disabled.");
+			this.logger.info("Auto creation of topics is disabled.");
 		}
 	}
 
@@ -449,7 +449,7 @@ public class KafkaMessageChannelBinder extends
 		final ZkUtils zkUtils = ZkUtils.apply(this.configurationProperties.getZkConnectionString(),
 				this.configurationProperties.getZkSessionTimeout(),
 				this.configurationProperties.getZkConnectionTimeout(),
-				JaasUtils.isZkSecurityEnabled());
+				JaasUtils.isZkSecurityEnabled() || this.configurationProperties.getZkJaas() != null);
 		try {
 			short errorCode = adminUtilsOperation.errorCodeFromTopicMetadata(topicName, zkUtils);
 			if (errorCode == ErrorMapping.NoError()) {

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -449,7 +449,7 @@ public class KafkaMessageChannelBinder extends
 		final ZkUtils zkUtils = ZkUtils.apply(this.configurationProperties.getZkConnectionString(),
 				this.configurationProperties.getZkSessionTimeout(),
 				this.configurationProperties.getZkConnectionTimeout(),
-				JaasUtils.isZkSecurityEnabled() || this.configurationProperties.getZkJaas() != null);
+				JaasUtils.isZkSecurityEnabled());
 		try {
 			short errorCode = adminUtilsOperation.errorCodeFromTopicMetadata(topicName, zkUtils);
 			if (errorCode == ErrorMapping.NoError()) {

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/JaasLoginModuleConfiguration.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/JaasLoginModuleConfiguration.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.springframework.util.Assert;
+
+/**
+ * Contains properties for setting up an {@link AppConfigurationEntry} that can be used
+ * for the Kafka or Zookeeper client.
+ *
+ * @author Marius Bogoevici
+ */
+public class JaasLoginModuleConfiguration {
+
+	private String loginModule = "com.sun.security.auth.module.Krb5LoginModule";
+
+	private AppConfigurationEntry.LoginModuleControlFlag controlFlag = AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+
+	private Map<String,String> options = new HashMap<>();
+
+	public String getLoginModule() {
+		return loginModule;
+	}
+
+	public void setLoginModule(String loginModule) {
+		Assert.notNull(loginModule, "cannot be null");
+		this.loginModule = loginModule;
+	}
+
+	public String getControlFlag() {
+		return controlFlag.toString();
+	}
+
+	public AppConfigurationEntry.LoginModuleControlFlag getControlFlagValue() {
+		return controlFlag;
+	}
+
+	public void setControlFlag(String controlFlag) {
+		Assert.notNull(controlFlag, "cannot be null");
+		if (AppConfigurationEntry.LoginModuleControlFlag.OPTIONAL.equals(controlFlag)) {
+			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.OPTIONAL;
+		}
+		else if (AppConfigurationEntry.LoginModuleControlFlag.REQUIRED.equals(controlFlag)) {
+			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+		}
+		else if (AppConfigurationEntry.LoginModuleControlFlag.REQUISITE.equals(controlFlag)) {
+			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.REQUISITE;
+		}
+		else if (AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT.equals(controlFlag)) {
+			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT;
+		}
+		else {
+			throw new IllegalArgumentException(controlFlag + " is not a supported control flag");
+		}
+	}
+
+	public Map<String, String> getOptions() {
+		return options;
+	}
+
+	public void setOptions(Map<String, String> options) {
+		this.options = options;
+	}
+}

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.kafka.KafkaBinderHealthIndicator;
+import org.springframework.cloud.stream.binder.kafka.KafkaBinderJaasInitializerListener;
 import org.springframework.cloud.stream.binder.kafka.KafkaExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.KafkaMessageChannelBinder;
 import org.springframework.cloud.stream.binder.kafka.admin.AdminUtilsOperation;
@@ -34,6 +35,7 @@ import org.springframework.cloud.stream.binder.kafka.admin.Kafka09AdminUtilsOper
 import org.springframework.cloud.stream.binder.kafka.admin.Kafka10AdminUtilsOperation;
 import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
@@ -116,6 +118,11 @@ public class KafkaBinderConfiguration {
 		return new Kafka10AdminUtilsOperation();
 	}
 
+	@Bean
+	public ApplicationListener<?> jaasInitializer() {
+		return new KafkaBinderJaasInitializerListener();
+	}
+
 	static class Kafka10Present implements Condition {
 
 		@Override
@@ -130,5 +137,12 @@ public class KafkaBinderConfiguration {
 		public boolean matches(ConditionContext conditionContext, AnnotatedTypeMetadata annotatedTypeMetadata) {
 			return AppInfoParser.getVersion().startsWith("0.9");
 		}
+	}
+
+	public static class JaasConfigurationProperties {
+
+		private JaasLoginModuleConfiguration kafka;
+
+		private JaasLoginModuleConfiguration zookeeper;
 	}
 }

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.config;
 
+import java.io.IOException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.common.utils.AppInfoParser;
@@ -119,7 +121,7 @@ public class KafkaBinderConfiguration {
 	}
 
 	@Bean
-	public ApplicationListener<?> jaasInitializer() {
+	public ApplicationListener<?> jaasInitializer() throws IOException {
 		return new KafkaBinderJaasInitializerListener();
 	}
 

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
@@ -79,8 +79,6 @@ public class KafkaBinderConfigurationProperties {
 
 	private JaasLoginModuleConfiguration jaas;
 
-	private JaasLoginModuleConfiguration zkJaas;
-
 	public String getZkConnectionString() {
 		return toConnectionString(this.zkNodes, this.defaultZkPort);
 	}
@@ -267,11 +265,4 @@ public class KafkaBinderConfigurationProperties {
 		this.jaas = jaas;
 	}
 
-	public JaasLoginModuleConfiguration getZkJaas() {
-		return zkJaas;
-	}
-
-	public void setZkJaas(JaasLoginModuleConfiguration zkJaas) {
-		this.zkJaas = zkJaas;
-	}
 }

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
@@ -77,6 +77,10 @@ public class KafkaBinderConfigurationProperties {
 
 	private int queueSize = 8192;
 
+	private JaasLoginModuleConfiguration jaas;
+
+	private JaasLoginModuleConfiguration zkJaas;
+
 	public String getZkConnectionString() {
 		return toConnectionString(this.zkNodes, this.defaultZkPort);
 	}
@@ -253,5 +257,21 @@ public class KafkaBinderConfigurationProperties {
 
 	public void setConfiguration(Map<String, String> configuration) {
 		this.configuration = configuration;
+	}
+
+	public JaasLoginModuleConfiguration getJaas() {
+		return jaas;
+	}
+
+	public void setJaas(JaasLoginModuleConfiguration jaas) {
+		this.jaas = jaas;
+	}
+
+	public JaasLoginModuleConfiguration getZkJaas() {
+		return zkJaas;
+	}
+
+	public void setZkJaas(JaasLoginModuleConfiguration zkJaas) {
+		this.zkJaas = zkJaas;
 	}
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
@@ -52,35 +52,7 @@ public class KafkaBinderJaasInitializerListenerTest {
 		assertThat(kafkaConfiguration[0].getOptions()).isEqualTo(kafkaConfigurationArray[0].getOptions());
 		context.close();
 	}
-
-	@Test
-	public void testConfigurationParsedCorrectlyWithKafkaAndZookeeper() throws Exception {
-		ConfigFile configFile = new ConfigFile(new ClassPathResource("jaas-sample-with-zk.conf").getURI());
-		final AppConfigurationEntry[] kafkaFileConfiguration = configFile.getAppConfigurationEntry(JaasUtils.LOGIN_CONTEXT_CLIENT);
-		final AppConfigurationEntry[] zkFileConfiguration = configFile.getAppConfigurationEntry(KafkaBinderJaasInitializerListener.DEFAULT_ZK_LOGIN_CONTEXT_NAME);
-
-		final ConfigurableApplicationContext context =
-				SpringApplication.run(SimpleApplication.class,
-						"--spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true",
-						"--spring.cloud.stream.kafka.binder.jaas.options.storeKey=true",
-						"--spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab",
-						"--spring.cloud.stream.kafka.binder.jaas.options.principal=kafka-client-1@EXAMPLE.COM",
-						"--spring.cloud.stream.kafka.binder.zkJaas.options.useKeyTab=true",
-						"--spring.cloud.stream.kafka.binder.zkJaas.options.storeKey=true",
-						"--spring.cloud.stream.kafka.binder.zkJaas.options.keyTab=/etc/security/keytabs/zk_client.keytab",
-						"--spring.cloud.stream.kafka.binder.zkJaas.options.principal=zk-client-1@EXAMPLE.COM");
-
-		javax.security.auth.login.Configuration configuration = javax.security.auth.login.Configuration.getConfiguration();
-
-		final AppConfigurationEntry[] kafkaConfiguration = configuration.getAppConfigurationEntry(JaasUtils.LOGIN_CONTEXT_CLIENT);
-		assertThat(kafkaConfiguration).hasSize(1);
-		assertThat(kafkaConfiguration[0].getOptions()).isEqualTo(kafkaFileConfiguration[0].getOptions());
-		final AppConfigurationEntry[] zkConfiguration = configuration.getAppConfigurationEntry(KafkaBinderJaasInitializerListener.DEFAULT_ZK_LOGIN_CONTEXT_NAME);
-		assertThat(zkConfiguration).hasSize(1);
-		assertThat(zkConfiguration[0].getOptions()).isEqualTo(zkFileConfiguration[0].getOptions());
-		context.close();
-	}
-
+	
 	@SpringBootApplication
 	public static class SimpleApplication {
 

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import com.sun.security.auth.login.ConfigFile;
+import org.apache.kafka.common.security.JaasUtils;
+import org.junit.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class KafkaBinderJaasInitializerListenerTest {
+
+	@Test
+	public void testConfigurationParsedCorrectlyWithKafkaClient() throws Exception {
+		ConfigFile configFile = new ConfigFile(new ClassPathResource("jaas-sample-kafka-only.conf").getURI());
+		final AppConfigurationEntry[] kafkaConfigurationArray = configFile.getAppConfigurationEntry(JaasUtils.LOGIN_CONTEXT_CLIENT);
+
+		final ConfigurableApplicationContext context =
+				SpringApplication.run(SimpleApplication.class,
+						"--spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true",
+						"--spring.cloud.stream.kafka.binder.jaas.options.storeKey=true",
+						"--spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab",
+						"--spring.cloud.stream.kafka.binder.jaas.options.principal=kafka-client-1@EXAMPLE.COM");
+		javax.security.auth.login.Configuration configuration = javax.security.auth.login.Configuration.getConfiguration();
+
+		final AppConfigurationEntry[] kafkaConfiguration = configuration.getAppConfigurationEntry(JaasUtils.LOGIN_CONTEXT_CLIENT);
+		assertThat(kafkaConfiguration).hasSize(1);
+		assertThat(kafkaConfiguration[0].getOptions()).isEqualTo(kafkaConfigurationArray[0].getOptions());
+		context.close();
+	}
+
+	@Test
+	public void testConfigurationParsedCorrectlyWithKafkaAndZookeeper() throws Exception {
+		ConfigFile configFile = new ConfigFile(new ClassPathResource("jaas-sample-with-zk.conf").getURI());
+		final AppConfigurationEntry[] kafkaFileConfiguration = configFile.getAppConfigurationEntry(JaasUtils.LOGIN_CONTEXT_CLIENT);
+		final AppConfigurationEntry[] zkFileConfiguration = configFile.getAppConfigurationEntry(KafkaBinderJaasInitializerListener.DEFAULT_ZK_LOGIN_CONTEXT_NAME);
+
+		final ConfigurableApplicationContext context =
+				SpringApplication.run(SimpleApplication.class,
+						"--spring.cloud.stream.kafka.binder.jaas.options.useKeyTab=true",
+						"--spring.cloud.stream.kafka.binder.jaas.options.storeKey=true",
+						"--spring.cloud.stream.kafka.binder.jaas.options.keyTab=/etc/security/keytabs/kafka_client.keytab",
+						"--spring.cloud.stream.kafka.binder.jaas.options.principal=kafka-client-1@EXAMPLE.COM",
+						"--spring.cloud.stream.kafka.binder.zkJaas.options.useKeyTab=true",
+						"--spring.cloud.stream.kafka.binder.zkJaas.options.storeKey=true",
+						"--spring.cloud.stream.kafka.binder.zkJaas.options.keyTab=/etc/security/keytabs/zk_client.keytab",
+						"--spring.cloud.stream.kafka.binder.zkJaas.options.principal=zk-client-1@EXAMPLE.COM");
+
+		javax.security.auth.login.Configuration configuration = javax.security.auth.login.Configuration.getConfiguration();
+
+		final AppConfigurationEntry[] kafkaConfiguration = configuration.getAppConfigurationEntry(JaasUtils.LOGIN_CONTEXT_CLIENT);
+		assertThat(kafkaConfiguration).hasSize(1);
+		assertThat(kafkaConfiguration[0].getOptions()).isEqualTo(kafkaFileConfiguration[0].getOptions());
+		final AppConfigurationEntry[] zkConfiguration = configuration.getAppConfigurationEntry(KafkaBinderJaasInitializerListener.DEFAULT_ZK_LOGIN_CONTEXT_NAME);
+		assertThat(zkConfiguration).hasSize(1);
+		assertThat(zkConfiguration[0].getOptions()).isEqualTo(zkFileConfiguration[0].getOptions());
+		context.close();
+	}
+
+	@SpringBootApplication
+	public static class SimpleApplication {
+
+	}
+}

--- a/spring-cloud-stream-binder-kafka/src/test/resources/jaas-sample-kafka-only.conf
+++ b/spring-cloud-stream-binder-kafka/src/test/resources/jaas-sample-kafka-only.conf
@@ -1,0 +1,7 @@
+KafkaClient {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/security/keytabs/kafka_client.keytab"
+    principal="kafka-client-1@EXAMPLE.COM";
+};

--- a/spring-cloud-stream-binder-kafka/src/test/resources/jaas-sample-with-zk.conf
+++ b/spring-cloud-stream-binder-kafka/src/test/resources/jaas-sample-with-zk.conf
@@ -1,0 +1,14 @@
+KafkaClient {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/security/keytabs/kafka_client.keytab"
+    principal="kafka-client-1@EXAMPLE.COM";
+};
+Client {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/etc/security/keytabs/zk_client.keytab"
+    principal="zk-client-1@EXAMPLE.COM";
+};


### PR DESCRIPTION
Fixes #36

Adds support for programmatic configurtion of JAAS
properties as an alternative to using a JAAS file.