### PR TITLE
Reinstate `spring-cloud-stream-binder-kafka-test-support`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
 		<module>spring-cloud-stream-binder-kafka-0.9-test</module>
 		<module>spring-cloud-stream-binder-kafka-0.10.0-test</module>
 		<module>spring-cloud-stream-binder-kafka-core</module>
-	</modules>
+        <module>spring-cloud-stream-binder-kafka-test-support</module>
+    </modules>
 
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-stream-binder-kafka-test-support/pom.xml
+++ b/spring-cloud-stream-binder-kafka-test-support/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-stream-binder-kafka-parent</artifactId>
+        <version>1.2.0.BUILD-SNAPSHOT</version>
+    </parent>
+    <artifactId>spring-cloud-stream-binder-kafka-test-support</artifactId>
+    <description>Kafka related test classes</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <version>${spring-kafka.version}</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Fix #102

We've removed it in favour of using `spring-kafka-test`
directly but that is somewhat inconvenient to the end
user. Also, it's still part of the release train BOM
so it's an oversight on our end.

(Needs to be cherry-picked to 1.1.x)