### PR TITLE
Added Kafka binder consumer lag metrics

### DIFF
--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 [[spring-cloud-stream-binder-kafka-reference]]
 = Spring Cloud Stream Kafka Binder Reference Guide
-Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinathan, Gunnar Hillert, Mark Pollack, Patrick Peralta, Glenn Renfro, Thomas Risberg, Dave Syer, David Turanski, Janne Valkealahti, Benjamin Klein
+Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinathan, Gunnar Hillert, Mark Pollack, Patrick Peralta, Glenn Renfro, Thomas Risberg, Dave Syer, David Turanski, Janne Valkealahti, Benjamin Klein, Henryk Konsek
 :doctype: book
 :toc:
 :toclevels: 4
@@ -24,6 +24,7 @@ Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinat
 = Reference Guide
 include::overview.adoc[]
 include::dlq.adoc[]
+include::metrics.adoc[]
 
 = Appendices
 [appendix]

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/metrics.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/metrics.adoc
@@ -1,0 +1,10 @@
+[[kafka-metrics]]
+== Kafka metrics
+
+Kafka binder module exposes the following metrics:
+
+`spring.cloud.stream.binder.kafka.someGroup.someTopic.lag`  - this metric indicates how many messages
+have not been yet consumed from given binder's topic (`someTopic`) by given consumer group (`someGroup`).
+For example if the value of the metric `spring.cloud.stream.binder.kafka.myGroup.myTopic.lag` is `1000`, then
+consumer group `myGroup` has `1000` messages to waiting to be consumed from topic `myTopic`. This metric is
+particularly useful to provide auto-scaling feedback to PaaS platform of your choice.

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.kafka.core.ConsumerFactory;
  *
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
+ * @author Henryk Konsek
  */
 public class KafkaBinderHealthIndicator implements HealthIndicator {
 
@@ -53,7 +54,7 @@ public class KafkaBinderHealthIndicator implements HealthIndicator {
 			for (String topic : this.binder.getTopicsInUse().keySet()) {
 				List<PartitionInfo> partitionInfos = metadataConsumer.partitionsFor(topic);
 				for (PartitionInfo partitionInfo : partitionInfos) {
-					if (this.binder.getTopicsInUse().get(topic).contains(partitionInfo) && partitionInfo.leader()
+					if (this.binder.getTopicsInUse().get(topic).getPartitionInfos().contains(partitionInfo) && partitionInfo.leader()
 							.id() == -1) {
 						downMessages.add(partitionInfo.toString());
 					}

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
@@ -16,19 +16,28 @@
 package org.springframework.cloud.stream.binder.kafka;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.endpoint.PublicMetrics;
 import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.core.env.PropertyResolver;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.util.ObjectUtils;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Collections.emptyList;
 
 /**
  * Metrics for Kafka binder.
@@ -37,45 +46,92 @@ import static java.util.Collections.emptyList;
  */
 public class KafkaBinderMetrics implements PublicMetrics {
 
-	static final String METRIC_PREFIX = "spring.stream.binder.kafka.topic.lag.";
+	private final static Logger LOG = LoggerFactory.getLogger(KafkaBinderMetrics.class);
+
+	static final String METRIC_PREFIX = "spring.cloud.stream.binder.kafka.bindings";
 
 	private final KafkaMessageChannelBinder binder;
 
-	private final ConsumerFactory<?, ?> consumerFactory;
+	private final KafkaBinderConfigurationProperties binderConfigurationProperties;
 
-	public KafkaBinderMetrics(KafkaMessageChannelBinder binder, ConsumerFactory<?, ?> consumerFactory) {
+	private final BindingServiceProperties bindingServiceProperties;
+
+	private final PropertyResolver propertyResolver;
+
+	private ConsumerFactory<?, ?> defaultConsumerFactory;
+
+	public KafkaBinderMetrics(KafkaMessageChannelBinder binder, KafkaBinderConfigurationProperties binderConfigurationProperties,
+			BindingServiceProperties bindingServiceProperties, PropertyResolver propertyResolver, ConsumerFactory<?, ?> defaultConsumerFactory) {
 		this.binder = binder;
-		this.consumerFactory = consumerFactory;
+		this.binderConfigurationProperties = binderConfigurationProperties;
+		this.bindingServiceProperties = bindingServiceProperties;
+		this.propertyResolver = propertyResolver;
+		this.defaultConsumerFactory = defaultConsumerFactory;
+	}
+
+	public KafkaBinderMetrics(KafkaMessageChannelBinder binder, KafkaBinderConfigurationProperties binderConfigurationProperties,
+			BindingServiceProperties bindingServiceProperties, PropertyResolver propertyResolver) {
+		this(binder, binderConfigurationProperties, bindingServiceProperties, propertyResolver, null);
 	}
 
 	@Override public Collection<Metric<?>> metrics() {
 		List<Metric<?>> metrics = new LinkedList<>();
-		try (Consumer<?, ?> metadataConsumer = consumerFactory.createConsumer()) {
-			for (Map.Entry<String, KafkaMessageChannelBinder.TopicInformation> topicInfo : this.binder.getTopicsInUse().entrySet()) {
-				if(!topicInfo.getValue().isConsumerTopic()) {
-					continue;
+		for (Map.Entry<String, KafkaMessageChannelBinder.TopicInformation> topicInfo : this.binder.getTopicsInUse().entrySet()) {
+			if (!topicInfo.getValue().isConsumerTopic()) {
+				continue;
+			}
+
+			String topic = topicInfo.getKey();
+			String binding = topic;
+			for(Map.Entry<String, BindingProperties> bindingProperties : bindingServiceProperties.getBindings().entrySet()) {
+				if(bindingProperties.getValue().getDestination() != null && bindingProperties.getValue().getDestination().equals(topic)) {
+					binding = bindingProperties.getKey();
 				}
-				String topic = topicInfo.getKey();
+			}
+			String group = propertyResolver.getProperty("spring.cloud.stream.bindings." + binding + ".group");
+			if(group == null) {
+				continue;
+			}
+
+			try (Consumer<?, ?> metadataConsumer = createConsumerFactory(group).createConsumer()) {
 				List<PartitionInfo> partitionInfos = metadataConsumer.partitionsFor(topic);
 				List<TopicPartition> topicPartitions = new LinkedList<>();
-				for(PartitionInfo partitionInfo : partitionInfos) {
+				for (PartitionInfo partitionInfo : partitionInfos) {
 					topicPartitions.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
 				}
 				Map<TopicPartition, Long> endOffsets = metadataConsumer.endOffsets(topicPartitions);
 				long lag = 0;
-				for(Map.Entry<TopicPartition, Long> endOffset : endOffsets.entrySet()) {
+				for (Map.Entry<TopicPartition, Long> endOffset : endOffsets.entrySet()) {
 					OffsetAndMetadata current = metadataConsumer.committed(endOffset.getKey());
-					if(current != null) {
+					if (current != null) {
 						lag += endOffset.getValue() - current.offset();
+					} else {
+						lag += endOffset.getValue();
 					}
 				}
-				metrics.add(new Metric<>(METRIC_PREFIX + topic, lag));
+				metrics.add(new Metric<>(String.format("%s.%s.%s.lag", METRIC_PREFIX, binding, group), lag));
+			} catch (Exception e) {
+				LOG.debug("Cannot generate metric for topic: " + topic, e);
 			}
-			return metrics;
 		}
-		catch (Exception e) {
-			return emptyList();
+		return metrics;
+	}
+
+	private ConsumerFactory<?,?> createConsumerFactory(String group) {
+		if(defaultConsumerFactory != null) {
+			return defaultConsumerFactory;
 		}
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+		if (!ObjectUtils.isEmpty(binderConfigurationProperties.getConfiguration())) {
+			props.putAll(binderConfigurationProperties.getConfiguration());
+		}
+		if (!props.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)) {
+			props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.binderConfigurationProperties.getKafkaConnectionString());
+		}
+		props.put("group.id", group);
+		return new DefaultKafkaConsumerFactory<>(props);
 	}
 
 }

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.binder.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.actuate.endpoint.PublicMetrics;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.kafka.core.ConsumerFactory;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Metrics for Kafka binder.
+ *
+ * @author Henryk Konsek
+ */
+public class KafkaBinderMetrics implements PublicMetrics {
+
+	static final String METRIC_PREFIX = "spring.stream.binder.kafka.topic.lag.";
+
+	private final KafkaMessageChannelBinder binder;
+
+	private final ConsumerFactory<?, ?> consumerFactory;
+
+	public KafkaBinderMetrics(KafkaMessageChannelBinder binder, ConsumerFactory<?, ?> consumerFactory) {
+		this.binder = binder;
+		this.consumerFactory = consumerFactory;
+	}
+
+	@Override public Collection<Metric<?>> metrics() {
+		List<Metric<?>> metrics = new LinkedList<>();
+		try (Consumer<?, ?> metadataConsumer = consumerFactory.createConsumer()) {
+			for (Map.Entry<String, KafkaMessageChannelBinder.TopicInformation> topicInfo : this.binder.getTopicsInUse().entrySet()) {
+				if(!topicInfo.getValue().isConsumerTopic()) {
+					continue;
+				}
+				String topic = topicInfo.getKey();
+				List<PartitionInfo> partitionInfos = metadataConsumer.partitionsFor(topic);
+				List<TopicPartition> topicPartitions = new LinkedList<>();
+				for(PartitionInfo partitionInfo : partitionInfos) {
+					topicPartitions.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
+				}
+				Map<TopicPartition, Long> endOffsets = metadataConsumer.endOffsets(topicPartitions);
+				long lag = 0;
+				for(Map.Entry<TopicPartition, Long> endOffset : endOffsets.entrySet()) {
+					OffsetAndMetadata current = metadataConsumer.committed(endOffset.getKey());
+					if(current != null) {
+						lag += endOffset.getValue() - current.offset();
+					}
+				}
+				metrics.add(new Metric<>(METRIC_PREFIX + topic, lag));
+			}
+			return metrics;
+		}
+		catch (Exception e) {
+			return emptyList();
+		}
+	}
+
+}

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -154,7 +154,7 @@ public class KafkaMessageChannelBinder extends
 						return producerFB.createProducer().partitionsFor(destination.getName());
 					}
 				});
-		this.topicsInUse.put(destination.getName(), new TopicInformation(false, partitions));
+		this.topicsInUse.put(destination.getName(), new TopicInformation(null, partitions));
 		if (producerProperties.getPartitionCount() < partitions.size()) {
 			if (this.logger.isInfoEnabled()) {
 				this.logger.info("The `partitionCount` of the producer for topic " + destination.getName() + " is "
@@ -236,7 +236,7 @@ public class KafkaMessageChannelBinder extends
 				}
 			}
 		}
-		this.topicsInUse.put(destination.getName(), new TopicInformation(true, listenedPartitions));
+		this.topicsInUse.put(destination.getName(), new TopicInformation(group, listenedPartitions));
 
 		Assert.isTrue(!CollectionUtils.isEmpty(listenedPartitions), "A list of partitions must be provided");
 		final TopicPartitionInitialOffset[] topicPartitionInitialOffsets = getTopicPartitionInitialOffsets(
@@ -411,17 +411,21 @@ public class KafkaMessageChannelBinder extends
 
 	public static class TopicInformation {
 
-		private final boolean consumerTopic;
+		private final String consumerGroup;
 
 		private final Collection<PartitionInfo> partitionInfos;
 
-		public TopicInformation(boolean consumerTopic, Collection<PartitionInfo> partitionInfos) {
-			this.consumerTopic = consumerTopic;
+		public TopicInformation(String consumerGroup, Collection<PartitionInfo> partitionInfos) {
+			this.consumerGroup = consumerGroup;
 			this.partitionInfos = partitionInfos;
 		}
 
+		public String getConsumerGroup() {
+			return consumerGroup;
+		}
+
 		public boolean isConsumerTopic() {
-			return consumerTopic;
+			return consumerGroup != null;
 		}
 
 		public Collection<PartitionInfo> getPartitionInfos() {

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -96,7 +96,7 @@ public class KafkaMessageChannelBinder extends
 
 	private KafkaExtendedBindingProperties extendedBindingProperties = new KafkaExtendedBindingProperties();
 
-	private final Map<String, Collection<PartitionInfo>> topicsInUse = new HashMap<>();
+	private final Map<String, TopicInformation> topicsInUse = new HashMap<>();
 
 	public KafkaMessageChannelBinder(KafkaBinderConfigurationProperties configurationProperties,
 			KafkaTopicProvisioner provisioningProvider) {
@@ -128,7 +128,7 @@ public class KafkaMessageChannelBinder extends
 		this.producerListener = producerListener;
 	}
 
-	Map<String, Collection<PartitionInfo>> getTopicsInUse() {
+	Map<String, TopicInformation> getTopicsInUse() {
 		return this.topicsInUse;
 	}
 
@@ -154,7 +154,7 @@ public class KafkaMessageChannelBinder extends
 						return producerFB.createProducer().partitionsFor(destination.getName());
 					}
 				});
-		this.topicsInUse.put(destination.getName(), partitions);
+		this.topicsInUse.put(destination.getName(), new TopicInformation(false, partitions));
 		if (producerProperties.getPartitionCount() < partitions.size()) {
 			if (this.logger.isInfoEnabled()) {
 				this.logger.info("The `partitionCount` of the producer for topic " + destination.getName() + " is "
@@ -236,7 +236,7 @@ public class KafkaMessageChannelBinder extends
 				}
 			}
 		}
-		this.topicsInUse.put(destination.getName(), listenedPartitions);
+		this.topicsInUse.put(destination.getName(), new TopicInformation(true, listenedPartitions));
 
 		Assert.isTrue(!CollectionUtils.isEmpty(listenedPartitions), "A list of partitions must be provided");
 		final TopicPartitionInitialOffset[] topicPartitionInitialOffsets = getTopicPartitionInitialOffsets(
@@ -408,4 +408,26 @@ public class KafkaMessageChannelBinder extends
 			return this.running;
 		}
 	}
+
+	public static class TopicInformation {
+
+		private final boolean consumerTopic;
+
+		private final Collection<PartitionInfo> partitionInfos;
+
+		public TopicInformation(boolean consumerTopic, Collection<PartitionInfo> partitionInfos) {
+			this.consumerTopic = consumerTopic;
+			this.partitionInfos = partitionInfos;
+		}
+
+		public boolean isConsumerTopic() {
+			return consumerTopic;
+		}
+
+		public Collection<PartitionInfo> getPartitionInfos() {
+			return partitionInfos;
+		}
+
+	}
+
 }

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
@@ -41,7 +41,6 @@ import org.springframework.cloud.stream.binder.kafka.properties.JaasLoginModuleC
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -51,7 +50,6 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.integration.codec.Codec;
 import org.springframework.kafka.core.ConsumerFactory;
@@ -137,10 +135,8 @@ public class KafkaBinderConfiguration {
 	}
 
 	@Bean
-	PublicMetrics kafkaBinderMetrics(KafkaMessageChannelBinder kafkaMessageChannelBinder, BindingServiceProperties bindingServiceProperties,
-			PropertyResolver propertyResolver) {
-		PublicMetrics metrics = new KafkaBinderMetrics(kafkaMessageChannelBinder, configurationProperties, bindingServiceProperties, propertyResolver);
-		return metrics;
+	PublicMetrics kafkaBinderMetrics(KafkaMessageChannelBinder kafkaMessageChannelBinder) {
+		return new KafkaBinderMetrics(kafkaMessageChannelBinder, configurationProperties);
 	}
 
 	@Bean(name = "adminUtilsOperation")

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderAutoConfigurationPropertiesTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderAutoConfigurationPropertiesTest.java
@@ -15,17 +15,10 @@
  */
 package org.springframework.cloud.stream.binder.kafka;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,6 +27,7 @@ import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfiguration;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -42,8 +36,15 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ReflectionUtils;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
@@ -115,5 +116,11 @@ public class KafkaBinderAutoConfigurationPropertiesTest {
 		KafkaProperties kafkaProperties() {
 			return new KafkaProperties();
 		}
+
+		@Bean
+		BindingServiceProperties bindingServiceProperties() {
+			return mock(BindingServiceProperties.class);
+		}
+
 	}
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderAutoConfigurationPropertiesTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderAutoConfigurationPropertiesTest.java
@@ -15,6 +15,12 @@
  */
 package org.springframework.cloud.stream.binder.kafka;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.junit.Test;
@@ -27,7 +33,6 @@ import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfiguration;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -36,15 +41,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ReflectionUtils;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
@@ -115,11 +113,6 @@ public class KafkaBinderAutoConfigurationPropertiesTest {
 		@Bean
 		KafkaProperties kafkaProperties() {
 			return new KafkaProperties();
-		}
-
-		@Bean
-		BindingServiceProperties bindingServiceProperties() {
-			return mock(BindingServiceProperties.class);
 		}
 
 	}

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationPropertiesTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationPropertiesTest.java
@@ -33,6 +33,9 @@ import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfiguration;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.test.context.TestPropertySource;
@@ -41,13 +44,15 @@ import org.springframework.util.ReflectionUtils;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = {KafkaBinderConfiguration.class})
+@SpringBootTest(classes = {KafkaBinderConfiguration.class, KafkaBinderConfigurationPropertiesTest.class})
 @TestPropertySource(locations = "classpath:binder-config.properties")
+@Configuration
 public class KafkaBinderConfigurationPropertiesTest {
 
 	@Autowired
@@ -86,4 +91,10 @@ public class KafkaBinderConfigurationPropertiesTest {
 		assertTrue(consumerConfigs.get("value.deserializer").equals(ByteArrayDeserializer.class));
 		assertTrue((((String) consumerConfigs.get("bootstrap.servers")).contains("10.98.09.199:9082")));
 	}
+
+	@Bean
+	BindingServiceProperties bindingServiceProperties() {
+		return mock(BindingServiceProperties.class);
+	}
+
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationPropertiesTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationPropertiesTest.java
@@ -33,9 +33,6 @@ import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfiguration;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.test.context.TestPropertySource;
@@ -44,7 +41,6 @@ import org.springframework.util.ReflectionUtils;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
@@ -52,7 +48,6 @@ import static org.mockito.Mockito.mock;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {KafkaBinderConfiguration.class, KafkaBinderConfigurationPropertiesTest.class})
 @TestPropertySource(locations = "classpath:binder-config.properties")
-@Configuration
 public class KafkaBinderConfigurationPropertiesTest {
 
 	@Autowired
@@ -90,11 +85,6 @@ public class KafkaBinderConfigurationPropertiesTest {
 		assertTrue(consumerConfigs.get("key.deserializer").equals(ByteArrayDeserializer.class));
 		assertTrue(consumerConfigs.get("value.deserializer").equals(ByteArrayDeserializer.class));
 		assertTrue((((String) consumerConfigs.get("bootstrap.servers")).contains("10.98.09.199:9082")));
-	}
-
-	@Bean
-	BindingServiceProperties bindingServiceProperties() {
-		return mock(BindingServiceProperties.class);
 	}
 
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationTest.java
@@ -23,22 +23,17 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfiguration;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ReflectionUtils;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {KafkaBinderConfiguration.class, KafkaBinderConfigurationTest.class})
-@Configuration
 public class KafkaBinderConfigurationTest {
 
 	@Autowired
@@ -54,11 +49,6 @@ public class KafkaBinderConfigurationTest {
 		ProducerListener producerListener = (ProducerListener) ReflectionUtils.getField(
 				producerListenerField, this.kafkaMessageChannelBinder);
 		assertNotNull(producerListener);
-	}
-
-	@Bean
-	BindingServiceProperties bindingServiceProperties() {
-		return mock(BindingServiceProperties.class);
 	}
 
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationTest.java
@@ -23,17 +23,22 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfiguration;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ReflectionUtils;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = KafkaBinderConfiguration.class)
+@SpringBootTest(classes = {KafkaBinderConfiguration.class, KafkaBinderConfigurationTest.class})
+@Configuration
 public class KafkaBinderConfigurationTest {
 
 	@Autowired
@@ -50,4 +55,10 @@ public class KafkaBinderConfigurationTest {
 				producerListenerField, this.kafkaMessageChannelBinder);
 		assertNotNull(producerListener);
 	}
+
+	@Bean
+	BindingServiceProperties bindingServiceProperties() {
+		return mock(BindingServiceProperties.class);
+	}
+
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicatorTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicatorTest.java
@@ -63,7 +63,7 @@ public class KafkaBinderHealthIndicatorTest {
 	@Test
 	public void kafkaBinderIsUp() {
 		final List<PartitionInfo> partitions = partitions(new Node(0, null, 0));
-		topicsInUse.put(TEST_TOPIC, new KafkaMessageChannelBinder.TopicInformation(true, partitions));
+		topicsInUse.put(TEST_TOPIC, new KafkaMessageChannelBinder.TopicInformation("group", partitions));
 		given(consumer.partitionsFor(TEST_TOPIC)).willReturn(partitions);
 		Health health = indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
@@ -72,7 +72,7 @@ public class KafkaBinderHealthIndicatorTest {
 	@Test
 	public void kafkaBinderIsDown() {
 		final List<PartitionInfo> partitions = partitions(new Node(-1, null, 0));
-		topicsInUse.put(TEST_TOPIC, new KafkaMessageChannelBinder.TopicInformation(true, partitions));
+		topicsInUse.put(TEST_TOPIC, new KafkaMessageChannelBinder.TopicInformation("group", partitions));
 		given(consumer.partitionsFor(TEST_TOPIC)).willReturn(partitions);
 		Health health = indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
@@ -25,10 +25,13 @@ import org.junit.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Marius Bogoevici
@@ -56,6 +59,11 @@ public class KafkaBinderJaasInitializerListenerTest {
 
 	@SpringBootApplication
 	public static class SimpleApplication {
+
+		@Bean
+		BindingServiceProperties bindingServiceProperties() {
+			return mock(BindingServiceProperties.class);
+		}
 
 	}
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderJaasInitializerListenerTest.java
@@ -25,13 +25,10 @@ import org.junit.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ClassPathResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Marius Bogoevici
@@ -59,11 +56,6 @@ public class KafkaBinderJaasInitializerListenerTest {
 
 	@SpringBootApplication
 	public static class SimpleApplication {
-
-		@Bean
-		BindingServiceProperties bindingServiceProperties() {
-			return mock(BindingServiceProperties.class);
-		}
 
 	}
 }


### PR DESCRIPTION
Hi,

I have created a simple metric indicating what is a current lag in a consumption of the Kafka messages for binding consumer. With this metric users can easily see if given microservice is too slow in consuming messages and should be scaled horizontally for example. I plan to use this metric in order to enable auto-scaling in Kubernetes for Spring Cloud Stream based microservices.

What do you think?