### PR TITLE
Allow consumer group.id to be overridden

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -324,6 +324,7 @@ public class KafkaMessageChannelBinder extends
 		props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
 		props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 100);
 		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, anonymous ? "latest" : "earliest");
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
 
 		if (!ObjectUtils.isEmpty(configurationProperties.getConfiguration())) {
 			props.putAll(configurationProperties.getConfiguration());
@@ -334,8 +335,6 @@ public class KafkaMessageChannelBinder extends
 		if (!ObjectUtils.isEmpty(consumerProperties.getExtension().getConfiguration())) {
 			props.putAll(consumerProperties.getExtension().getConfiguration());
 		}
-
-		props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
 		if (!ObjectUtils.isEmpty(consumerProperties.getExtension().getStartOffset())) {
 			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, consumerProperties.getExtension().getStartOffset().name());
 		}

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderAutoConfigurationPropertiesTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderAutoConfigurationPropertiesTest.java
@@ -86,7 +86,7 @@ public class KafkaBinderAutoConfigurationPropertiesTest {
 		Map<String, Object> consumerConfigs = (Map<String, Object>) ReflectionUtils.getField(consumerFactoryConfigField, consumerFactory);
 		assertTrue(consumerConfigs.get("key.deserializer").equals(LongDeserializer.class));
 		assertTrue(consumerConfigs.get("value.deserializer").equals(LongDeserializer.class));
-		assertTrue(consumerConfigs.get("group.id").equals("test"));
+		assertTrue(consumerConfigs.get("group.id").equals("groupIdFromBootConfig"));
 		assertTrue(consumerConfigs.get("auto.offset.reset").equals("earliest"));
 		assertTrue((((List<String>) consumerConfigs.get("bootstrap.servers")).containsAll(bootstrapServers)));
 	}

--- a/spring-cloud-stream-binder-kafka/src/test/resources/binder-config-autoconfig.properties
+++ b/spring-cloud-stream-binder-kafka/src/test/resources/binder-config-autoconfig.properties
@@ -7,4 +7,4 @@ spring.kafka.bootstrapServers=10.98.09.199:9092,10.98.09.196:9092
 spring.kafka.producer.compressionType=snappy
 # Test consumer properties
 spring.kafka.consumer.auto-offset-reset=earliest
-spring.kafka.consumer.group-id=testEmbeddedKafkaApplication
+spring.kafka.consumer.group-id=groupIdFromBootConfig


### PR DESCRIPTION
  - This change will allow consumer's group.id to be overridden from possible options (Spring Boot Kafka properties, binder configuration properties etc.,)

Resolves #149