### PR TITLE
Separate each sentence into its own line in metrics docs

### DIFF
--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/metrics.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/metrics.adoc
@@ -1,10 +1,8 @@
 [[kafka-metrics]]
-== Kafka metrics
+== Kafka Metrics
 
 Kafka binder module exposes the following metrics:
 
-`spring.cloud.stream.binder.kafka.someGroup.someTopic.lag`  - this metric indicates how many messages
-have not been yet consumed from given binder's topic (`someTopic`) by given consumer group (`someGroup`).
-For example if the value of the metric `spring.cloud.stream.binder.kafka.myGroup.myTopic.lag` is `1000`, then
-consumer group `myGroup` has `1000` messages to waiting to be consumed from topic `myTopic`. This metric is
-particularly useful to provide auto-scaling feedback to PaaS platform of your choice.
+`spring.cloud.stream.binder.kafka.someGroup.someTopic.lag`  - this metric indicates how many messages have not been yet consumed from given binder's topic by given consumer group.
+For example if the value of the metric `spring.cloud.stream.binder.kafka.myGroup.myTopic.lag` is `1000`, then consumer group `myGroup` has `1000` messages to waiting to be consumed from topic `myTopic`.
+This metric is particularly useful to provide auto-scaling feedback to PaaS platform of your choice.


### PR DESCRIPTION
Not sure why issue #201 is happening. Trying this commit as a fix (if docs missing is due to some asciidoc restriction). 