### PR TITLE
GH-231: reuse Kafka consumer HealthIndicator

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -41,6 +41,7 @@ import org.springframework.kafka.core.ConsumerFactory;
  * @author Marius Bogoevici
  * @author Henryk Konsek
  * @author Gary Russell
+ * @author Laur Aliste
  */
 public class KafkaBinderHealthIndicator implements HealthIndicator {
 
@@ -52,15 +53,16 @@ public class KafkaBinderHealthIndicator implements HealthIndicator {
 
 	private int timeout = DEFAULT_TIMEOUT;
 
-	public KafkaBinderHealthIndicator(KafkaMessageChannelBinder binder,
-			ConsumerFactory<?, ?> consumerFactory) {
+	private Consumer<?, ?> metadataConsumer;
+
+	public KafkaBinderHealthIndicator(KafkaMessageChannelBinder binder, ConsumerFactory<?, ?> consumerFactory) {
 		this.binder = binder;
 		this.consumerFactory = consumerFactory;
-
 	}
 
 	/**
 	 * Set the timeout in seconds to retrieve health information.
+	 *
 	 * @param timeout the timeout - default 60.
 	 */
 	public void setTimeout(int timeout) {
@@ -74,7 +76,10 @@ public class KafkaBinderHealthIndicator implements HealthIndicator {
 
 			@Override
 			public Health call() {
-				try (Consumer<?, ?> metadataConsumer = consumerFactory.createConsumer()) {
+				try {
+					if (metadataConsumer == null) {
+						metadataConsumer = consumerFactory.createConsumer();
+					}
 					Set<String> downMessages = new HashSet<>();
 					for (String topic : KafkaBinderHealthIndicator.this.binder.getTopicsInUse().keySet()) {
 						List<PartitionInfo> partitionInfos = metadataConsumer.partitionsFor(topic);
@@ -113,8 +118,7 @@ public class KafkaBinderHealthIndicator implements HealthIndicator {
 			return Health.down(e).build();
 		}
 		catch (TimeoutException e) {
-			return Health.down()
-					.withDetail("Failed to retrieve partition information in", this.timeout + " seconds")
+			return Health.down().withDetail("Failed to retrieve partition information in", this.timeout + " seconds")
 					.build();
 		}
 		finally {


### PR DESCRIPTION
- lazily create Consumer in KafkaBinderHealthIndicator.


Suspect KafkaConsumer's lifecycle doesn't allow for this naive implementation, but it's a start.

Resolves spring-cloud/spring-cloud-stream-binder-kafka#231