### PR TITLE
GH-236: Backwards Compatibility

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -97,6 +98,11 @@ public class KafkaBinderConfigurationProperties {
 	private int healthTimeout = 60;
 
 	private JaasLoginModuleConfiguration jaas;
+
+	/**
+	 * The bean name of a custom header mapper to use instead of a {@link DefaultKafkaHeaderMapper}.
+	 */
+	private String headerMapperBeanName;
 
 	public Transaction getTransaction() {
 		return this.transaction;
@@ -356,6 +362,14 @@ public class KafkaBinderConfigurationProperties {
 
 	public void setJaas(JaasLoginModuleConfiguration jaas) {
 		this.jaas = jaas;
+	}
+
+	public String getHeaderMapperBeanName() {
+		return this.headerMapperBeanName;
+	}
+
+	public void setHeaderMapperBeanName(String headerMapperBeanName) {
+		this.headerMapperBeanName = headerMapperBeanName;
 	}
 
 	public static class Transaction {

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.utils.Utils;
@@ -43,6 +44,7 @@ import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
+import org.springframework.cloud.stream.binder.HeaderMode;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaExtendedBindingProperties;
@@ -67,6 +69,7 @@ import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.config.ContainerProperties;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.KafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.kafka.support.SendResult;
@@ -112,7 +115,7 @@ public class KafkaMessageChannelBinder extends
 
 	public KafkaMessageChannelBinder(KafkaBinderConfigurationProperties configurationProperties,
 			KafkaTopicProvisioner provisioningProvider) {
-		super(true, null, provisioningProvider);
+		super(headersToMap(configurationProperties), provisioningProvider);
 		this.configurationProperties = configurationProperties;
 		if (StringUtils.hasText(configurationProperties.getTransaction().getTransactionIdPrefix())) {
 			this.transactionManager = new KafkaTransactionManager<>(
@@ -122,6 +125,22 @@ public class KafkaMessageChannelBinder extends
 		else {
 			this.transactionManager = null;
 		}
+	}
+
+	private static String[] headersToMap(KafkaBinderConfigurationProperties configurationProperties) {
+		String[] headersToMap;
+		if (ObjectUtils.isEmpty(configurationProperties.getHeaders())) {
+			headersToMap = BinderHeaders.STANDARD_HEADERS;
+		}
+		else {
+			String[] combinedHeadersToMap = Arrays.copyOfRange(BinderHeaders.STANDARD_HEADERS, 0,
+					BinderHeaders.STANDARD_HEADERS.length + configurationProperties.getHeaders().length);
+			System.arraycopy(configurationProperties.getHeaders(), 0, combinedHeadersToMap,
+					BinderHeaders.STANDARD_HEADERS.length,
+					configurationProperties.getHeaders().length);
+			headersToMap = combinedHeadersToMap;
+		}
+		return headersToMap;
 	}
 
 	public void setExtendedBindingProperties(KafkaExtendedBindingProperties extendedBindingProperties) {
@@ -194,19 +213,32 @@ public class KafkaMessageChannelBinder extends
 		if (errorChannel != null) {
 			handler.setSendFailureChannel(errorChannel);
 		}
-		String[] headerPatterns = producerProperties.getExtension().getHeaderPatterns();
-		if (headerPatterns != null && headerPatterns.length > 0) {
-			List<String> patterns = new LinkedList<>(Arrays.asList(headerPatterns));
-			if (!patterns.contains("!" + MessageHeaders.TIMESTAMP)) {
-				patterns.add(0, "!" + MessageHeaders.TIMESTAMP);
-			}
-			if (!patterns.contains("!" + MessageHeaders.ID)) {
-				patterns.add(0, "!" + MessageHeaders.ID);
-			}
-			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper(
-					patterns.toArray(new String[patterns.size()]));
-			handler.setHeaderMapper(headerMapper);
+		KafkaHeaderMapper mapper;
+		if (this.configurationProperties.getHeaderMapperBeanName() != null) {
+			mapper = getApplicationContext().getBean(this.configurationProperties.getHeaderMapperBeanName(),
+					KafkaHeaderMapper.class);
 		}
+		if (producerProperties.getHeaderMode() != null
+				&& !HeaderMode.headers.equals(producerProperties.getHeaderMode())) {
+			mapper = null;
+		}
+		else {
+			String[] headerPatterns = producerProperties.getExtension().getHeaderPatterns();
+			if (headerPatterns != null && headerPatterns.length > 0) {
+				List<String> patterns = new LinkedList<>(Arrays.asList(headerPatterns));
+				if (!patterns.contains("!" + MessageHeaders.TIMESTAMP)) {
+					patterns.add(0, "!" + MessageHeaders.TIMESTAMP);
+				}
+				if (!patterns.contains("!" + MessageHeaders.ID)) {
+					patterns.add(0, "!" + MessageHeaders.ID);
+				}
+				mapper = new DefaultKafkaHeaderMapper(patterns.toArray(new String[patterns.size()]));
+			}
+			else {
+				mapper = new DefaultKafkaHeaderMapper();
+			}
+		}
+		handler.setHeaderMapper(mapper);
 		return handler;
 	}
 
@@ -326,12 +358,30 @@ public class KafkaMessageChannelBinder extends
 		final KafkaMessageDrivenChannelAdapter<?, ?> kafkaMessageDrivenChannelAdapter = new KafkaMessageDrivenChannelAdapter<>(
 				messageListenerContainer);
 		MessagingMessageConverter messageConverter = new MessagingMessageConverter();
-		DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
-		String[] trustedPackages = extendedConsumerProperties.getExtension().getTrustedPackages();
-		if (!StringUtils.isEmpty(trustedPackages)) {
-			headerMapper.addTrustedPackages(trustedPackages);
+		KafkaHeaderMapper mapper = null;
+		if (this.configurationProperties.getHeaderMapperBeanName() != null) {
+			mapper = getApplicationContext().getBean(this.configurationProperties.getHeaderMapperBeanName(),
+					KafkaHeaderMapper.class);
 		}
-		messageConverter.setHeaderMapper(headerMapper);
+		if (mapper == null) {
+			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper() {
+
+				@Override
+				public void toHeaders(Headers source, Map<String, Object> headers) {
+					super.toHeaders(source, headers);
+					if (headers.size() > 0) {
+						headers.put(BinderHeaders.NATIVE_HEADERS_PRESENT, Boolean.TRUE);
+					}
+				}
+
+			};
+			String[] trustedPackages = extendedConsumerProperties.getExtension().getTrustedPackages();
+			if (!StringUtils.isEmpty(trustedPackages)) {
+				headerMapper.addTrustedPackages(trustedPackages);
+			}
+			mapper = headerMapper;
+		}
+		messageConverter.setHeaderMapper(mapper);
 		kafkaMessageDrivenChannelAdapter.setMessageConverter(messageConverter);
 		kafkaMessageDrivenChannelAdapter.setBeanFactory(this.getBeanFactory());
 		ErrorInfrastructure errorInfrastructure = registerErrorInfrastructure(destination, consumerGroup,

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -213,16 +213,21 @@ public class KafkaMessageChannelBinder extends
 		if (errorChannel != null) {
 			handler.setSendFailureChannel(errorChannel);
 		}
-		KafkaHeaderMapper mapper;
+		KafkaHeaderMapper mapper = null;
 		if (this.configurationProperties.getHeaderMapperBeanName() != null) {
 			mapper = getApplicationContext().getBean(this.configurationProperties.getHeaderMapperBeanName(),
 					KafkaHeaderMapper.class);
 		}
+		/*
+		 *  Even if the user configures a bean, we must not use it if the header
+		 *  mode is not the default (headers); setting the mapper to null
+		 *  disables populating headers in the message handler.
+		 */
 		if (producerProperties.getHeaderMode() != null
 				&& !HeaderMode.headers.equals(producerProperties.getHeaderMode())) {
 			mapper = null;
 		}
-		else {
+		else if (mapper == null) {
 			String[] headerPatterns = producerProperties.getExtension().getHeaderPatterns();
 			if (headerPatterns != null && headerPatterns.length > 0) {
 				List<String> patterns = new LinkedList<>(Arrays.asList(headerPatterns));


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/236

- Restore the mapped headers configuration for embedding headers
- Configure the header mapper based on the header mode
- On the outbound side, set the mapper to `null` unless the header mode is not null and not `headers`
  this suppresses the channel adapter from setting up headers - for compatibility with < 0.11 brokers
- On the inbound side, set the `BinderHeaders.NATIVE_HEADERS_PRESENT` header if native headers found
- Add a configuration capability allowing the user to provide his/her own header mapper

- Add a test case with 3 producers (embedded, native, and no headers) and a consumer to verify it can
  consume all 3

Requires https://github.com/spring-cloud/spring-cloud-stream/pull/1107

Resolves spring-cloud/spring-cloud-stream#1106