### PR TITLE
GH-239: Fix dependency for the kafka11 starter

### DIFF
--- a/spring-cloud-starter-stream-kafka11/pom.xml
+++ b/spring-cloud-starter-stream-kafka11/pom.xml
@@ -19,7 +19,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-kafka</artifactId>
+			<artifactId>spring-cloud-stream-binder-kafka11</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/239

Note: merge to 0.11, not master