### PR TITLE
GH-251: Configurable inbound adapter converter

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
@@ -23,12 +23,35 @@ import java.util.Map;
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
+ * @author Gary Russell
  *
  * <p>
  * Thanks to Laszlo Szabo for providing the initial patch for generic property support.
  * </p>
  */
 public class KafkaConsumerProperties {
+
+	public enum StartOffset {
+		earliest(-2L),
+		latest(-1L);
+
+		private final long referencePoint;
+
+		StartOffset(long referencePoint) {
+			this.referencePoint = referencePoint;
+		}
+
+		public long getReferencePoint() {
+			return this.referencePoint;
+		}
+	}
+
+	public enum StandardHeaders {
+		none,
+		id,
+		timestamp,
+		both
+	}
 
 	private boolean autoRebalanceEnabled = true;
 
@@ -47,6 +70,10 @@ public class KafkaConsumerProperties {
 	private int recoveryInterval = 5000;
 
 	private String[] trustedPackages;
+
+	private StandardHeaders standardHeaders = StandardHeaders.none;
+
+	private String converterBeanName;
 
 	private Map<String, String> configuration = new HashMap<>();
 
@@ -98,21 +125,6 @@ public class KafkaConsumerProperties {
 		this.autoRebalanceEnabled = autoRebalanceEnabled;
 	}
 
-	public enum StartOffset {
-		earliest(-2L),
-		latest(-1L);
-
-		private final long referencePoint;
-
-		StartOffset(long referencePoint) {
-			this.referencePoint = referencePoint;
-		}
-
-		public long getReferencePoint() {
-			return this.referencePoint;
-		}
-	}
-
 	public Map<String, String> getConfiguration() {
 		return this.configuration;
 	}
@@ -144,4 +156,20 @@ public class KafkaConsumerProperties {
 	public void setDlqProducerProperties(KafkaProducerProperties dlqProducerProperties) {
 		this.dlqProducerProperties = dlqProducerProperties;
 	}
+	public StandardHeaders getStandardHeaders() {
+		return this.standardHeaders;
+	}
+
+	public void setStandardHeaders(StandardHeaders standardHeaders) {
+		this.standardHeaders = standardHeaders;
+	}
+
+	public String getConverterBeanName() {
+		return this.converterBeanName;
+	}
+
+	public void setConverterBeanName(String converterBeanName) {
+		this.converterBeanName = converterBeanName;
+	}
+
 }

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -191,6 +191,16 @@ dlqProducerProperties::
   All the properties available through kafka producer properties can be set through this property.
 +
 Default: Default Kafka producer properties.
+standardHeaders::
+  Indicates which standard headers are populated by the inbound channel adapter.
+  `none`, `id`, `timestamp` or `both`.
+  Useful if using native deserialization and the first component to receive a message needs an `id` (such as an aggregator that is configured to use a JDBC message store).
++
+Default: `none`
+converterBeanName::
+  The name of a bean that implements `RecordMessageConverter`; used in the inbound channel adapter to replace the default `MessagingMessageConverter`.
++
+Default: `null`
 
 [[kafka-producer-properties]]
 === Kafka Producer Properties


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/251

When using native decoding, the message emitted by the binder has no `id` or `timestamp`
headers. This can cause problems if the first SI endpoint uses a JDBC message store,
for example.

Add the ability to configure whether these headers are populated as well as the ability
to inject a custom message converter.