### PR TITLE
Configure dlq producer properties

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
@@ -22,6 +22,7 @@ import java.util.Map;
 /**
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
+ * @author Soby Chacko
  *
  * <p>
  * Thanks to Laszlo Szabo for providing the initial patch for generic property support.
@@ -40,6 +41,8 @@ public class KafkaConsumerProperties {
 	private boolean enableDlq;
 
 	private String dlqName;
+
+	private KafkaProducerProperties dlqProducerProperties = new KafkaProducerProperties();
 
 	private int recoveryInterval = 5000;
 
@@ -132,5 +135,13 @@ public class KafkaConsumerProperties {
 
 	public void setTrustedPackages(String[] trustedPackages) {
 		this.trustedPackages = trustedPackages;
+	}
+
+	public KafkaProducerProperties getDlqProducerProperties() {
+		return dlqProducerProperties;
+	}
+
+	public void setDlqProducerProperties(KafkaProducerProperties dlqProducerProperties) {
+		this.dlqProducerProperties = dlqProducerProperties;
 	}
 }

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -186,6 +186,11 @@ dlqName::
   The name of the DLQ topic to receive the error messages.
 +
 Default: null (If not specified, messages that result in errors will be forwarded to a topic named `error.<destination>.<group>`).
+dlqProducerProperties::
+  Using this, dlq specific producer properties can be set.
+  All the properties available through kafka producer properties can be set through this property.
++
+Default: Default Kafka producer properties.
 
 [[kafka-producer-properties]]
 === Kafka Producer Properties


### PR DESCRIPTION
This PR in core needs to be merged first for this PR to build: https://github.com/spring-cloud/spring-cloud-stream/pull/1138

Fixes #58

- add the ability to configure the dlq producer properties
- new property on KafkaConsumerProperties for dlqProducerProperties
- dlq sender refactoring in Kafka binder
- make dlq type raw so that non byte[] key/payloads can be sent
- add new tests for verifying dlq producer properties