### PR TITLE
SCST-GH-989: Log WARN when sending to DLQ [1.2.x only]

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -295,6 +295,9 @@ public class KafkaMessageChannelBinder extends
 
 				@Override
 				public void handle(Exception thrownException, final ConsumerRecord message) {
+					if (logger.isWarnEnabled()) {
+						logger.warn("Sending to DLQ:" + message, thrownException);
+					}
 					final byte[] key = message.key() != null ? Utils.toArray(ByteBuffer.wrap((byte[]) message.key()))
 							: null;
 					final byte[] payload = message.value() != null


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream/issues/989

Previously, when `enableDlq` is set, the message was sent to the DLQ
but no error was logged (as is the case when there is no DLQ).

1.2.x only because the SI error logger logs the condition in 1.3+.