### PR TITLE
Support for KStream branch and split

### DIFF
--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -608,26 +608,16 @@ Keys will not get converted, but if the Serdes are different for keys from what 
 Kafka Streams allow outbound data to be split into multiple topics based on some predicates.
 Spring Cloud Stream Kafka Streams binder provides support for this feature without losing the overall programming model exposed through `StreamListener` in the end user application.
 You write the application in the usual way as demonstrated above in the word count example.
-The actual splitting and branching into multiple topics are done by the framework behind the scenes.
-When using the branching feature, you are required to do two things.
-First, you need to provide the following property that specifies the extra branches (topics) in the order.
-The first topic will always be the one specified through the main outbound destination.
-
-`spring.cloud.stream.kstream.bindings.output.producer.additionalBranches=foo,bar`
-
-If your main output destination is foobar provided through `spring.cloud.stream.bindings.output.destination=foobar`, then your 3 output branches (topics) are foobar, foo and bar.
-
-Second, you need to provide a `Bean` in your application context, that returns a `org.apache.kafka.streams.kstream.Predicate[]`.
-The presence of this bean is the trigger to the framework to perform branching into multiple topics.
-The individual Predicates in this bean, should match with the output branches in the same order.
-Each Predicate should get its own output branch, otherwise, it fails.
-If you provide more output branches than there are Predicates, that is fine, but the number of branches cannot be less than the Predicates.
+When using the branching feature, you are required to do a few things.
+First, you need to make sure that your return type is `KStream[]` instead of a regular `KStream`.
+Then you need to use the `SendTo` annotation containing the output bindings in the order (example below).
+For each of these output bindings, you need to configure destination, content-type etc. as required by any other standard Spring Cloud Stream application
 
 Here is an example:
 
 [source]
 ----
-@EnableBinding(KStreamProcessor.class)
+@EnableBinding(KStreamProcessorWithBranches.class)
 @EnableAutoConfiguration
 public static class WordCountProcessorApplication {
 
@@ -635,25 +625,37 @@ public static class WordCountProcessorApplication {
     private TimeWindows timeWindows;
 
     @StreamListener("input")
-    @SendTo("output")
-    public KStream<?, WordCount> process(KStream<Object, String> input) {
-        return input
-                .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
-                .groupBy((key, value) -> value)
-                .windowedBy(timeWindows)
-                .count(Materialized.as("WordCounts-1"))
-                .toStream()
-                .map((key, value) -> new KeyValue<>(null, new WordCount(key.key(), value, new Date(key.window().start()), new Date(key.window().end()))));
+    @SendTo({"output1","output2","output3})
+    public KStream<?, WordCount>[] process(KStream<Object, String> input) {
+
+			Predicate<Object, WordCount> isEnglish = (k, v) -> v.word.equals("english");
+			Predicate<Object, WordCount> isFrench =  (k, v) -> v.word.equals("french");
+			Predicate<Object, WordCount> isSpanish = (k, v) -> v.word.equals("spanish");
+
+			return input
+					.flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
+					.groupBy((key, value) -> value)
+					.windowedBy(timeWindows)
+					.count(Materialized.as("WordCounts-1"))
+					.toStream()
+					.map((key, value) -> new KeyValue<>(null, new WordCount(key.key(), value, new Date(key.window().start()), new Date(key.window().end()))))
+					.branch(isEnglish, isFrench, isSpanish);
     }
 
-    @Bean
-    public Predicate[] predicates() {
-        Predicate<?, WordCount> isEnglish = (k, v) -> v.word.equals("english");
-        Predicate<?, WordCount> isFrench =  (k, v) -> v.word.equals("french");
-        Predicate<?, WordCount> isSpanish = (k, v) -> v.word.equals("spanish");
-        return new Predicate[] {isEnglish, isFrench, isSpanish};
-    }
+    interface KStreamProcessorWithBranches {
 
+    		@Input("input")
+    		KStream<?, ?> input();
+
+    		@Output("output1")
+    		KStream<?, ?> output1();
+
+    		@Output("output2")
+    		KStream<?, ?> output2();
+
+    		@Output("output3")
+    		KStream<?, ?> output3();
+    	}
 }
 ----
 
@@ -661,16 +663,25 @@ Then in the properties:
 
 [source]
 ----
-spring.cloud.stream.bindings.output.contentType: application/json
+spring.cloud.stream.bindings.output1.contentType: application/json
+spring.cloud.stream.bindings.output2.contentType: application/json
+spring.cloud.stream.bindings.output3.contentType: application/json
 spring.cloud.stream.kstream.binder.configuration.commit.interval.ms: 1000
 spring.cloud.stream.kstream.binder.configuration:
   key.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
   value.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
-spring.cloud.stream.bindings.output:
-  destination: foobar
+spring.cloud.stream.bindings.output1:
+  destination: foo
   producer:
     headerMode: raw
-spring.cloud.stream.kstream.bindings.output.producer.additionalBranches: foo,bar
+spring.cloud.stream.bindings.output2:
+  destination: bar
+  producer:
+    headerMode: raw
+spring.cloud.stream.bindings.output3:
+  destination: fox
+  producer:
+    headerMode: raw
 spring.cloud.stream.bindings.input:
   destination: words
   consumer:
@@ -708,13 +719,6 @@ For instance, you can use a different Serde for your input or output destination
 ----
 spring.cloud.stream.kstream.bindings.output.producer.keySerde=org.apache.kafka.common.serialization.Serdes$IntegerSerde
 spring.cloud.stream.kstream.bindings.output.producer.valueSerde=org.apache.kafka.common.serialization.Serdes$LongSerde
-----
-
-Additional output branches:
-
-[source]
-----
-spring.cloud.stream.kstream.bindings.output.producer.additionalBranches (comma separated values)
 ----
 
 TimeWindow properties:

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -590,7 +590,7 @@ Similarly, if the following property is set (default is false), any message conv
 
 `spring.cloud.stream.bindings.input.consumer.useNativeDecoding`.
 
-When native encoding is disabled, then the messages on the outbound are converted by Spring Cloud Stream using the provided contentType.
+When native encoding is disabled, then the messages on the outbound are converted by Spring Cloud Stream using the provided `contentType` header.
 If no contentType is set by the application, it defaults to `application/json`.
 
 By default, all the out of the box message converters, serialize the data as `byte[]` encoding the proper contentType.

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -524,7 +524,8 @@ Spring Cloud Stream Kafka support also includes a binder specifically designed f
 Using this binder, applications can be written that leverage the Kafka Streams API.
 For more information on Kafka Streams, see https://kafka.apache.org/documentation/streams/developer-guide[Kafka Streams API Developer Manual]
 
-Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project. For details on that support, see http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams[Kafaka Streams Support in Spring Kafka].
+Kafka Streams support in Spring Cloud Stream is based on the foundations provided by the Spring Kafka project.
+For details on that support, see http://docs.spring.io/spring-kafka/reference/html/_reference.html#kafka-streams[Kafaka Streams Support in Spring Kafka].
 
 Here are the maven coordinates for the Spring Cloud Stream KStream binder artifact.
 
@@ -536,8 +537,8 @@ Here are the maven coordinates for the Spring Cloud Stream KStream binder artifa
 </dependency>
 ----
 
-In addition to leveraging the Spring Cloud Stream programming model which is based on Spring Boot, one of the main other benefits that the KStream binder provides is the fact that it avoids the boilerplate configuration that one needs to write when using the Kafka Streams API directly.
-High level streams DSL provided through the Kafka Streams API can be used through Spring Cloud Stream in the current support.
+High level streams DSL provided through the Kafka Streams API can be used through Spring Cloud Stream support.
+Kafka Streams applications using the Spring Cloud Stream support can only be written using the processor model, i.e. messages read from an inbound topic and messages written to an outbound topic.
 
 === Usage example of high level streams DSL
 
@@ -553,36 +554,134 @@ public class WordCountProcessorApplication {
 	@SendTo("output")
 	public KStream<?, String> process(KStream<?, String> input) {
 		return input
-				.flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
-				.map((key, word) -> new KeyValue<>(word, word))
-				.groupByKey(Serdes.String(), Serdes.String())
-				.count(TimeWindows.of(5000), "store-name")
-				.toStream()
-				.map((w, c) -> new KeyValue<>(null, "Count for " + w.key() + ": " + c));
-	}
+                .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
+                .groupBy((key, value) -> value)
+                .windowedBy(TimeWindows.of(5000))
+                .count(Materialized.as("WordCounts-multi"))
+                .toStream()
+                .map((key, value) -> new KeyValue<>(null, new WordCount(key.key(), value, new Date(key.window().start()), new Date(key.window().end()))));
+    }
 
 	public static void main(String[] args) {
 		SpringApplication.run(WordCountProcessorApplication.class, args);
 	}
 ----
 
-If you build it as Spring Boot runnable fat jar, you can run the above example in the following way:
+If you build it as a Spring Boot uber jar, you can run the above example in the following way:
 
 [source]
 ----
 java -jar uber.jar  --spring.cloud.stream.bindings.input.destination=words --spring.cloud.stream.bindings.output.destination=counts
 ----
 
-This means that the application will listen from the incoming Kafka topic words and write to the output topic counts.
+This means that the application will listen from the incoming Kafka topic `words` and write to the output topic `counts`.
 
 Spring Cloud Stream will ensure that the messages from both the incoming and outgoing topics are bound as KStream objects.
-As one may observe, the developer can exclusively focus on the business aspects of the code, i.e. writing the logic required in the processor rather than setting up the streams specific configuration required by the Kafka Streams infrastructure.
-All those boilerplate is handled by Spring Cloud Stream behind the scenes.
+Applications can exclusively focus on the business aspects of the code, i.e. writing the logic required in the processor rather than setting up the streams specific configuration required by the Kafka Streams infrastructure.
+All such interactions are handled by the framework.
+
+=== Message conversion in Spring Cloud Stream Kafka Streams applications
+
+If the following property is set (default is false), the framework skips all message conversions on the outbound (producer) side and it is then done by Kafka itself.
+
+`spring.cloud.stream.bindings.output.producer.useNativeEncoding`.
+
+Similarly, if the following property is set (default is false), any message conversion is skipped on the inbound (consumer) side and natively done by Kafka.
+
+`spring.cloud.stream.bindings.input.consumer.useNativeDecoding`.
+
+When native encoding is disabled, then the messages on the outbound are converted by Spring Cloud Stream using the provided contentType.
+If no contentType is set by the application, it defaults to `application/json`.
+
+By default, all the out of the box message converters, serialize the data as `byte[]` encoding the proper contentType.
+In most situations, this is what you want to do, but if other formats than `byte[]` are desired, then ann appropriate message converter needs to be registered in the context and corresponding contentType specified as a property.
+When doing this way, Serdes should be overridden on the producer using the following property.
+
+`spring.cloud.stream.kstream.bindings.output.producer.valueSerde`.
+
+Keys will not get converted, but if the Serdes are different for keys from what is given as the common Serde, you can override that using the following property.
+
+`spring.cloud.stream.kstream.bindings.output.producer.keySerde`.
+
+=== Support for branching in Kafka Streams API
+
+Kafka Streams allow outbound data to be split into multiple topics based on some predicates.
+Spring Cloud Stream Kafka Streams binder provides support for this feature without losing the overall programming model exposed through `StreamListener` in the end user application.
+You write the application in the usual way as demonstrated above in the word count example.
+The actual splitting and branching into multiple topics are done by the framework behind the scenes.
+When using the branching feature, you are required to do two things.
+First, you need to provide the following property that specifies the extra branches (topics) in the order.
+The first topic will always be the one specified through the main outbound destination.
+
+`spring.cloud.stream.kstream.bindings.output.producer.additionalBranches=foo,bar`
+
+If your main output destination is foobar provided through `spring.cloud.stream.bindings.output.destination=foobar`, then your 3 output branches (topics) are foobar, foo and bar.
+
+Second, you need to provide a `Bean` in your application context, that returns a `org.apache.kafka.streams.kstream.Predicate[]`.
+The presence of this bean is the trigger to the framework to perform branching into multiple topics.
+The individual Predicates in this bean, should match with the output branches in the same order.
+Each Predicate should get its own output branch, otherwise, it fails.
+If you provide more output branches than there are Predicates, that is fine, but the number of branches cannot be less than the Predicates.
+
+Here is an example:
+
+[source]
+----
+@EnableBinding(KStreamProcessor.class)
+@EnableAutoConfiguration
+public static class WordCountProcessorApplication {
+
+    @Autowired
+    private TimeWindows timeWindows;
+
+    @StreamListener("input")
+    @SendTo("output")
+    public KStream<?, WordCount> process(KStream<Object, String> input) {
+        return input
+                .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
+                .groupBy((key, value) -> value)
+                .windowedBy(timeWindows)
+                .count(Materialized.as("WordCounts-1"))
+                .toStream()
+                .map((key, value) -> new KeyValue<>(null, new WordCount(key.key(), value, new Date(key.window().start()), new Date(key.window().end()))));
+    }
+
+    @Bean
+    public Predicate[] predicates() {
+        Predicate<?, WordCount> isEnglish = (k, v) -> v.word.equals("english");
+        Predicate<?, WordCount> isFrench =  (k, v) -> v.word.equals("french");
+        Predicate<?, WordCount> isSpanish = (k, v) -> v.word.equals("spanish");
+        return new Predicate[] {isEnglish, isFrench, isSpanish};
+    }
+
+}
+----
+
+Then in the properties:
+
+[source]
+----
+spring.cloud.stream.bindings.output.contentType: application/json
+spring.cloud.stream.kstream.binder.configuration.commit.interval.ms: 1000
+spring.cloud.stream.kstream.binder.configuration:
+  key.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
+  value.serde: org.apache.kafka.common.serialization.Serdes$StringSerde
+spring.cloud.stream.bindings.output:
+  destination: foobar
+  producer:
+    headerMode: raw
+spring.cloud.stream.kstream.bindings.output.producer.additionalBranches: foo,bar
+spring.cloud.stream.bindings.input:
+  destination: words
+  consumer:
+    headerMode: raw
+----
 
 === Support for interactive queries
 
 If access to the `KafkaStreams` is needed for interactive queries, the internal `KafkaStreams` instance can be accessed via `KStreamBuilderFactoryBean.getKafkaStreams()`.
-You can autowire the `KStreamBuilderFactoryBean` instance provided by the KStream binder. Then you can get `KafkaStreams` instance from it and retrieve the underlying store, execute queries on it, etc.
+You can autowire the `KStreamBuilderFactoryBean` instance provided by the KStream binder.
+Then you get `KafkaStreams` instance from it and retrieve the underlying store, execute queries on it, etc.
 
 === Kafka Streams properties
 
@@ -599,7 +698,7 @@ spring.cloud.stream.kstream.binder.configuration.value.serde=org.apache.kafka.co
 spring.cloud.stream.kstream.binder.configuration.commit.interval.ms=1000
 ----
 
-  For more information about all the properties that may go into streams configuration, see StreamsConfig JavaDocs.
+For more information about all the properties that may go into streams configuration, see StreamsConfig JavaDocs.
 
 There can also be binding specific properties.
 
@@ -609,6 +708,24 @@ For instance, you can use a different Serde for your input or output destination
 ----
 spring.cloud.stream.kstream.bindings.output.producer.keySerde=org.apache.kafka.common.serialization.Serdes$IntegerSerde
 spring.cloud.stream.kstream.bindings.output.producer.valueSerde=org.apache.kafka.common.serialization.Serdes$LongSerde
+----
+
+Additional output branches:
+
+[source]
+----
+spring.cloud.stream.kstream.bindings.output.producer.additionalBranches (comma separated values)
+----
+
+TimeWindow properties:
+
+[source]
+----
+spring.cloud.stream.kstream.timeWindow.length (milliseconds)
+
+When this property is given, you can autowire a `TimeWindows` bean into the application.
+
+spring.cloud.stream.kstream.timeWindow.advanceBy (milliseconds)
 ----
 
 [[kafka-error-channels]]

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/KStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/KStreamListenerSetupMethodOrchestrator.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kstream;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import org.apache.kafka.streams.kstream.KStream;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binding.StreamListenerErrorMessages;
+import org.springframework.cloud.stream.binding.StreamListenerParameterAdapter;
+import org.springframework.cloud.stream.binding.StreamListenerResultAdapter;
+import org.springframework.cloud.stream.binding.StreamListenerSetupMethodOrchestrator;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Kafka Streams specific implementation for {@link StreamListenerSetupMethodOrchestrator}
+ * that overrides the default mechanisms for invoking StreamListener adapters.
+ *
+ * @author Soby Chacko
+ */
+public class KStreamListenerSetupMethodOrchestrator implements StreamListenerSetupMethodOrchestrator, ApplicationContextAware {
+
+	private ConfigurableApplicationContext applicationContext;
+
+	private StreamListenerParameterAdapter streamListenerParameterAdapter;
+	private Collection<StreamListenerResultAdapter> streamListenerResultAdapters;
+
+	public KStreamListenerSetupMethodOrchestrator(StreamListenerParameterAdapter streamListenerParameterAdapter,
+												Collection<StreamListenerResultAdapter> streamListenerResultAdapters) {
+		this.streamListenerParameterAdapter = streamListenerParameterAdapter;
+		this.streamListenerResultAdapters = streamListenerResultAdapters;
+	}
+
+	@Override
+	public boolean supports(Method method) {
+		return methodParameterSuppports(method) && methodReturnTypeSuppports(method);
+	}
+
+	private boolean methodReturnTypeSuppports(Method method) {
+		Class<?> returnType = method.getReturnType();
+		if (returnType.equals(KStream.class) ||
+				(returnType.isArray() && returnType.getComponentType().equals(KStream.class))) {
+			return true;
+		}
+		return false;
+	}
+
+	private boolean methodParameterSuppports(Method method) {
+		MethodParameter methodParameter = MethodParameter.forExecutable(method, 0);
+		Class<?> parameterType = methodParameter.getParameterType();
+		return parameterType.equals(KStream.class);
+	}
+
+	@Override
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public void orchestrateStreamListenerSetupMethod(StreamListener streamListener, Method method, Object bean) {
+		String[] methodAnnotatedOutboundNames = getOutboundBindingTargetNames(method);
+		validateStreamListenerMethod(streamListener, method, methodAnnotatedOutboundNames);
+
+		String methodAnnotatedInboundName = streamListener.value();
+		Object[] adaptedInboundArguments = adaptAndRetrieveInboundArguments(method, methodAnnotatedInboundName,
+				this.applicationContext,
+				this.streamListenerParameterAdapter);
+
+		try {
+			Object result = method.invoke(bean, adaptedInboundArguments);
+
+			if (result.getClass().isArray()) {
+				Assert.isTrue(methodAnnotatedOutboundNames.length == ((Object[]) result).length, "Big error");
+			} else {
+				Assert.isTrue(methodAnnotatedOutboundNames.length == 1, "Big error");
+			}
+			if (result.getClass().isArray()) {
+				Object[] outboundKStreams = (Object[]) result;
+				int i = 0;
+				for (Object outboundKStream : outboundKStreams) {
+					Object targetBean = this.applicationContext.getBean(methodAnnotatedOutboundNames[i++]);
+					for (StreamListenerResultAdapter streamListenerResultAdapter : streamListenerResultAdapters) {
+						if (streamListenerResultAdapter.supports(outboundKStream.getClass(), targetBean.getClass())) {
+							streamListenerResultAdapter.adapt(outboundKStream, targetBean);
+							break;
+						}
+					}
+				}
+			}
+			else {
+				Object targetBean = this.applicationContext.getBean(methodAnnotatedOutboundNames[0]);
+				for (StreamListenerResultAdapter streamListenerResultAdapter : streamListenerResultAdapters) {
+					if (streamListenerResultAdapter.supports(result.getClass(), targetBean.getClass())) {
+						streamListenerResultAdapter.adapt(result, targetBean);
+						break;
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			throw new BeanInitializationException("Cannot setup StreamListener for " + method, e);
+		}
+	}
+
+	@Override
+	public final void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+	}
+
+	private void validateStreamListenerMethod(StreamListener streamListener, Method method, String[] methodAnnotatedOutboundNames) {
+		String methodAnnotatedInboundName = streamListener.value();
+		for (String s : methodAnnotatedOutboundNames) {
+			if (StringUtils.hasText(s)) {
+				Assert.isTrue(isDeclarativeOutput(method, s), "Method must be declarative");
+			}
+		}
+		if (StringUtils.hasText(methodAnnotatedInboundName)) {
+			int methodArgumentsLength = method.getParameterTypes().length;
+
+			for (int parameterIndex = 0; parameterIndex < methodArgumentsLength; parameterIndex++) {
+				MethodParameter methodParameter = MethodParameter.forExecutable(method, parameterIndex);
+				Assert.isTrue(isDeclarativeInput(methodAnnotatedInboundName, methodParameter), "Method must be declarative");
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private boolean isDeclarativeOutput(Method m, String targetBeanName) {
+		boolean declarative;
+		Class<?> returnType = m.getReturnType();
+		if (returnType.isArray()){
+			Class<?> targetBeanClass = this.applicationContext.getType(targetBeanName);
+			declarative = this.streamListenerResultAdapters.stream()
+					.anyMatch(slpa -> slpa.supports(returnType.getComponentType(), targetBeanClass));
+			return declarative;
+		}
+		Class<?> targetBeanClass = this.applicationContext.getType(targetBeanName);
+		declarative = this.streamListenerResultAdapters.stream()
+				.anyMatch(slpa -> slpa.supports(returnType, targetBeanClass));
+		return declarative;
+	}
+
+	@SuppressWarnings("unchecked")
+	private boolean isDeclarativeInput(String targetBeanName, MethodParameter methodParameter) {
+		if (!methodParameter.getParameterType().isAssignableFrom(Object.class) && this.applicationContext.containsBean(targetBeanName)) {
+			Class<?> targetBeanClass = this.applicationContext.getType(targetBeanName);
+			return this.streamListenerParameterAdapter.supports(targetBeanClass, methodParameter);
+		}
+		return false;
+	}
+
+	private static String[] getOutboundBindingTargetNames(Method method) {
+		SendTo sendTo = AnnotationUtils.findAnnotation(method, SendTo.class);
+		if (sendTo != null) {
+			Assert.isTrue(!ObjectUtils.isEmpty(sendTo.value()), StreamListenerErrorMessages.ATLEAST_ONE_OUTPUT);
+			Assert.isTrue(sendTo.value().length >= 1, "At least one outbound destination need to be provided.");
+			return sendTo.value();
+		}
+		return null;
+	}
+}

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/KStreamStreamListenerResultAdapter.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/KStreamStreamListenerResultAdapter.java
@@ -23,8 +23,6 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KStream;
 
 import org.springframework.cloud.stream.binding.StreamListenerResultAdapter;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
 
 /**
  * @author Marius Bogoevici
@@ -39,16 +37,7 @@ public class KStreamStreamListenerResultAdapter implements StreamListenerResultA
 	@Override
 	@SuppressWarnings("unchecked")
 	public Closeable adapt(KStream streamListenerResult, KStreamBoundElementFactory.KStreamWrapper boundElement) {
-		boundElement.wrap(streamListenerResult.map((k, v) -> {
-			KeyValue<Object, Object> keyValue;
-			if (v instanceof Message<?>) {
-				keyValue = new KeyValue<>(k, v);
-			}
-			else {
-				keyValue = new KeyValue<>(k, MessageBuilder.withPayload(v).build());
-			}
-			return keyValue;
-		}));
+		boundElement.wrap(streamListenerResult.map(KeyValue::new));
 		return new NoOpCloseable();
 	}
 

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/MessageConversionDelegate.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/MessageConversionDelegate.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kstream;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeType;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Soby Chacko
+ */
+public class MessageConversionDelegate {
+
+	private final BindingServiceProperties bindingServiceProperties;
+	private final CompositeMessageConverterFactory compositeMessageConverterFactory;
+
+	public MessageConversionDelegate(BindingServiceProperties bindingServiceProperties,
+									CompositeMessageConverterFactory compositeMessageConverterFactory) {
+		this.bindingServiceProperties = bindingServiceProperties;
+		this.compositeMessageConverterFactory = compositeMessageConverterFactory;
+	}
+
+	public KeyValueMapper<Object, Object, KeyValue<Object, Object>> outboundKeyValueMapper(String name) {
+		BindingProperties bindingProperties = bindingServiceProperties.getBindingProperties(name);
+		String contentType = bindingProperties.getContentType();
+		MessageConverter messageConverter = StringUtils.hasText(contentType) ? compositeMessageConverterFactory
+				.getMessageConverterForType(MimeType.valueOf(contentType))
+				: null;
+
+		return (k, v) -> {
+			Message<?> message = v instanceof Message<?> ? (Message<?>)v :
+					MessageBuilder.withPayload(v).build();
+			Map<String, Object> headers = new HashMap<>(message.getHeaders());
+			if (!StringUtils.isEmpty(contentType)) {
+				headers.put(MessageHeaders.CONTENT_TYPE, contentType);
+			}
+			MessageHeaders messageHeaders = new MessageHeaders(headers);
+			return new KeyValue<>(k,
+					messageConverter.toMessage(message.getPayload(),
+							messageHeaders).getPayload());
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	public KeyValueMapper<Object, Object, KeyValue<Object, Object>> inboundKeyValueMapper(Class<?> valueClass) {
+		MessageConverter messageConverter = compositeMessageConverterFactory.getMessageConverterForAllRegistered();
+		return (KeyValueMapper) (o, o2) -> {
+			KeyValue<Object, Object> keyValue;
+			if (valueClass.isAssignableFrom(o2.getClass())) {
+				keyValue =  new KeyValue<>(o, o2);
+			}
+			else if (o2 instanceof Message) {
+				if (valueClass.isAssignableFrom(((Message) o2).getPayload().getClass())) {
+					keyValue = new KeyValue<>(o, ((Message) o2).getPayload());
+				}
+				else {
+					keyValue = new KeyValue<>(o, messageConverter.fromMessage((Message) o2, valueClass));
+				}
+			}
+			else if(o2 instanceof String || o2 instanceof byte[]) {
+				Message<Object> message = MessageBuilder.withPayload(o2).build();
+				keyValue =  new KeyValue<>(o, messageConverter.fromMessage(message, valueClass));
+			}
+			else {
+				keyValue =  new KeyValue<>(o, o2);
+			}
+			return keyValue;
+		};
+	}
+}

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.binder.kstream.config;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Predicate;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -26,6 +27,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner;
 import org.springframework.cloud.stream.binder.kstream.KStreamBinder;
+import org.springframework.cloud.stream.binder.kstream.MessageConversionDelegate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -43,6 +45,9 @@ public class KStreamBinderConfiguration {
 	@Autowired
 	private KafkaProperties kafkaProperties;
 
+	@Autowired(required = false)
+	private Predicate[] predicates;
+
 	@Bean
 	public KafkaTopicProvisioner provisioningProvider(KafkaBinderConfigurationProperties binderConfigurationProperties) {
 		return new KafkaTopicProvisioner(binderConfigurationProperties, kafkaProperties);
@@ -51,9 +56,14 @@ public class KStreamBinderConfiguration {
 	@Bean
 	public KStreamBinder kStreamBinder(KafkaBinderConfigurationProperties binderConfigurationProperties,
 									KafkaTopicProvisioner kafkaTopicProvisioner,
-									KStreamExtendedBindingProperties kStreamExtendedBindingProperties, StreamsConfig streamsConfig) {
-		return new KStreamBinder(binderConfigurationProperties, kafkaTopicProvisioner, kStreamExtendedBindingProperties,
-				streamsConfig);
+									KStreamExtendedBindingProperties kStreamExtendedBindingProperties, StreamsConfig streamsConfig,
+									MessageConversionDelegate messageConversionDelegate) {
+		KStreamBinder kStreamBinder = new KStreamBinder(binderConfigurationProperties, kafkaTopicProvisioner, kStreamExtendedBindingProperties,
+				streamsConfig, messageConversionDelegate);
+		if (predicates != null) {
+			kStreamBinder.setPredicates(predicates);
+		}
+		return kStreamBinder;
 	}
 
 }

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamBinderConfiguration.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.binder.kstream.config;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.kstream.Predicate;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -45,9 +44,6 @@ public class KStreamBinderConfiguration {
 	@Autowired
 	private KafkaProperties kafkaProperties;
 
-	@Autowired(required = false)
-	private Predicate[] predicates;
-
 	@Bean
 	public KafkaTopicProvisioner provisioningProvider(KafkaBinderConfigurationProperties binderConfigurationProperties) {
 		return new KafkaTopicProvisioner(binderConfigurationProperties, kafkaProperties);
@@ -60,9 +56,6 @@ public class KStreamBinderConfiguration {
 									MessageConversionDelegate messageConversionDelegate) {
 		KStreamBinder kStreamBinder = new KStreamBinder(binderConfigurationProperties, kafkaTopicProvisioner, kStreamExtendedBindingProperties,
 				streamsConfig, messageConversionDelegate);
-		if (predicates != null) {
-			kStreamBinder.setPredicates(predicates);
-		}
 		return kStreamBinder;
 	}
 

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamBinderSupportAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamBinderSupportAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.binder.kstream.config;
 
+import java.util.Collection;
 import java.util.Properties;
 
 import org.apache.kafka.common.serialization.Serdes;
@@ -29,8 +30,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kstream.KStreamBoundElementFactory;
 import org.springframework.cloud.stream.binder.kstream.KStreamListenerParameterAdapter;
+import org.springframework.cloud.stream.binder.kstream.KStreamListenerSetupMethodOrchestrator;
 import org.springframework.cloud.stream.binder.kstream.KStreamStreamListenerResultAdapter;
 import org.springframework.cloud.stream.binder.kstream.MessageConversionDelegate;
+import org.springframework.cloud.stream.binding.StreamListenerResultAdapter;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
 import org.springframework.context.annotation.Bean;
@@ -88,6 +91,13 @@ public class KStreamBinderSupportAutoConfiguration {
 	public KStreamListenerParameterAdapter kafkaStreamListenerParameterAdapter(
 			MessageConversionDelegate messageConversionDelegate) {
 		return new KStreamListenerParameterAdapter(messageConversionDelegate);
+	}
+
+	@Bean
+	public KStreamListenerSetupMethodOrchestrator kStreamListenerSetupMethodOrchestrator(
+			KStreamListenerParameterAdapter kafkaStreamListenerParameterAdapter,
+			Collection<StreamListenerResultAdapter> streamListenerResultAdapters){
+		return new KStreamListenerSetupMethodOrchestrator(kafkaStreamListenerParameterAdapter, streamListenerResultAdapters);
 	}
 
 	@Bean

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamProducerProperties.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamProducerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,17 @@ package org.springframework.cloud.stream.binder.kstream.config;
 
 /**
  * @author Marius Bogoevici
+ * @author Soby Chacko
  */
 public class KStreamProducerProperties extends KStreamCommonProperties {
 
+	private String additionalBranches;
+
+	public String getAdditionalBranches() {
+		return additionalBranches;
+	}
+
+	public void setAdditionalBranches(String additionalBranches) {
+		this.additionalBranches = additionalBranches;
+	}
 }

--- a/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamProducerProperties.java
+++ b/spring-cloud-stream-binder-kstream/src/main/java/org/springframework/cloud/stream/binder/kstream/config/KStreamProducerProperties.java
@@ -22,13 +22,4 @@ package org.springframework.cloud.stream.binder.kstream.config;
  */
 public class KStreamProducerProperties extends KStreamCommonProperties {
 
-	private String additionalBranches;
-
-	public String getAdditionalBranches() {
-		return additionalBranches;
-	}
-
-	public void setAdditionalBranches(String additionalBranches) {
-		this.additionalBranches = additionalBranches;
-	}
 }

--- a/spring-cloud-stream-binder-kstream/src/test/java/org/springframework/cloud/stream/binder/kstream/WordCountMultipleBranchesIntegrationTests.java
+++ b/spring-cloud-stream-binder-kstream/src/test/java/org/springframework/cloud/stream/binder/kstream/WordCountMultipleBranchesIntegrationTests.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kstream;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binder.kstream.annotations.KStreamProcessor;
+import org.springframework.cloud.stream.binder.kstream.config.KStreamApplicationSupportProperties;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.handler.annotation.SendTo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ * @author Soby Chacko
+ * @author Gary Russell
+ */
+public class WordCountMultipleBranchesIntegrationTests {
+
+	@ClassRule
+	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, "counts","foo","bar");
+
+	private static Consumer<String, String> consumer;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("group", "false", embeddedKafka);
+		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+		DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		consumer = cf.createConsumer();
+		embeddedKafka.consumeFromEmbeddedTopics(consumer, "counts", "foo", "bar");
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		consumer.close();
+	}
+
+	@Test
+	public void testKstreamWordCountWithStringInputAndPojoOuput() throws Exception {
+		SpringApplication app = new SpringApplication(WordCountProcessorApplication.class);
+		app.setWebEnvironment(false);
+
+		ConfigurableApplicationContext context = app.run("--server.port=0",
+				"--spring.cloud.stream.bindings.input.destination=words",
+				"--spring.cloud.stream.bindings.output.destination=counts",
+				"--spring.cloud.stream.bindings.output.contentType=application/json",
+				"--spring.cloud.stream.kstream.binder.configuration.commit.interval.ms=1000",
+				"--spring.cloud.stream.kstream.binder.configuration.key.serde=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.kstream.binder.configuration.value.serde=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.kstream.bindings.output.producer.additionalBranches=foo,bar",
+				"--spring.cloud.stream.bindings.output.producer.headerMode=raw",
+				"--spring.cloud.stream.bindings.input.consumer.headerMode=raw",
+				"--spring.cloud.stream.kstream.timeWindow.length=5000",
+				"--spring.cloud.stream.kstream.timeWindow.advanceBy=0",
+				"--spring.cloud.stream.kstream.binder.brokers=" + embeddedKafka.getBrokersAsString(),
+				"--spring.cloud.stream.kstream.binder.zkNodes=" + embeddedKafka.getZookeeperConnectionString());
+		try {
+			receiveAndValidate(context);
+		} finally {
+			context.close();
+		}
+	}
+
+	private void receiveAndValidate(ConfigurableApplicationContext context) throws Exception {
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf, true);
+		template.setDefaultTopic("words");
+		template.sendDefault("english");
+		ConsumerRecord<String, String> cr = KafkaTestUtils.getSingleRecord(consumer, "counts");
+		assertThat(cr.value().contains("\"word\":\"english\",\"count\":1")).isTrue();
+
+		template.sendDefault("french");
+		template.sendDefault("french");
+		cr = KafkaTestUtils.getSingleRecord(consumer, "foo");
+		assertThat(cr.value().contains("\"word\":\"french\",\"count\":2")).isTrue();
+
+		template.sendDefault("spanish");
+		template.sendDefault("spanish");
+		template.sendDefault("spanish");
+		cr = KafkaTestUtils.getSingleRecord(consumer, "bar");
+		assertThat(cr.value().contains("\"word\":\"spanish\",\"count\":3")).isTrue();
+	}
+
+	@EnableBinding(KStreamProcessor.class)
+	@EnableAutoConfiguration
+	@EnableConfigurationProperties(KStreamApplicationSupportProperties.class)
+	public static class WordCountProcessorApplication {
+
+		@Autowired
+		private TimeWindows timeWindows;
+
+		@StreamListener("input")
+		@SendTo("output")
+		public KStream<?, WordCount> process(KStream<Object, String> input) {
+			return input
+					.flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
+					.groupBy((key, value) -> value)
+					.windowedBy(timeWindows)
+					.count(Materialized.as("WordCounts-multi"))
+					.toStream()
+					.map((key, value) -> new KeyValue<>(null, new WordCount(key.key(), value, new Date(key.window().start()), new Date(key.window().end()))));
+		}
+
+		@Bean
+		public Predicate[] predicates() {
+			Predicate<?, WordCount> isEnglish = (k, v) -> v.word.equals("english");
+			Predicate<?, WordCount> isFrench =  (k, v) -> v.word.equals("french");
+			Predicate<?, WordCount> isSpanish = (k, v) -> v.word.equals("spanish");
+			return new Predicate[] {isEnglish, isFrench, isSpanish};
+		}
+
+	}
+
+	static class WordCount {
+
+		private String word;
+
+		private long count;
+
+		private Date start;
+
+		private Date end;
+
+		WordCount(String word, long count, Date start, Date end) {
+			this.word = word;
+			this.count = count;
+			this.start = start;
+			this.end = end;
+		}
+
+		public String getWord() {
+			return word;
+		}
+
+		public void setWord(String word) {
+			this.word = word;
+		}
+
+		public long getCount() {
+			return count;
+		}
+
+		public void setCount(long count) {
+			this.count = count;
+		}
+
+		public Date getStart() {
+			return start;
+		}
+
+		public void setStart(Date start) {
+			this.start = start;
+		}
+
+		public Date getEnd() {
+			return end;
+		}
+
+		public void setEnd(Date end) {
+			this.end = end;
+		}
+	}
+
+}


### PR DESCRIPTION
Resolves #265

- Ensure that branching can be done and any message conversions
  done on all outbound data to multiple topics
- Refine MessageConversion logic in KStream binder
- Refactor message conversion code into a specific class
- Cleanup and refactoring
- Test to verify branching support
- More refinements in the way nativeEncoding/nativeDecoding logic works in KStream binder
- Doc changes for KStream binder