### PR TITLE
SCST-GH-1166: Support Producer-initiated tx [0.11 back port]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<properties>
 		<java.version>1.7</java.version>
 		<kafka.version>0.11.0.0</kafka.version>
-		<spring-kafka.version>1.3.0.RELEASE</spring-kafka.version>
+		<spring-kafka.version>1.3.2.RELEASE</spring-kafka.version>
 		<spring-integration-kafka.version>2.3.0.RELEASE</spring-integration-kafka.version>
 		<spring-cloud-stream.version>1.3.1.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<spring-cloud-build.version>1.3.5.RELEASE</spring-cloud-build.version>


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/276

Previously, transactions were only supported if initiated by a consumer.