### PR TITLE
requestedAcks propoerty changed to string to allow setting it to "all"

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -83,7 +83,7 @@ public class KafkaBinderConfigurationProperties {
 	 */
 	private int zkConnectionTimeout = 10000;
 
-	private int requiredAcks = 1;
+	private String requiredAcks = "1";
 
 	private int replicationFactor = 1;
 
@@ -219,11 +219,15 @@ public class KafkaBinderConfigurationProperties {
 		this.maxWait = maxWait;
 	}
 
-	public int getRequiredAcks() {
+	public String getRequiredAcks() {
 		return this.requiredAcks;
 	}
 
 	public void setRequiredAcks(int requiredAcks) {
+		this.requiredAcks = String.valueOf(requiredAcks);
+	}
+
+	public void setRequiredAcks(String requiredAcks) {
 		this.requiredAcks = requiredAcks;
 	}
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsDlqDispatch.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsDlqDispatch.java
@@ -103,7 +103,7 @@ class KafkaStreamsDlqDispatch {
 		Map<String, Object> props = new HashMap<>();
 		props.put(ProducerConfig.RETRIES_CONFIG, 0);
 		props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
-		props.put(ProducerConfig.ACKS_CONFIG, String.valueOf(configurationProperties.getRequiredAcks()));
+		props.put(ProducerConfig.ACKS_CONFIG, configurationProperties.getRequiredAcks());
 		if (!ObjectUtils.isEmpty(configurationProperties.getProducerConfiguration())) {
 			props.putAll(configurationProperties.getProducerConfiguration());
 		}

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -114,6 +114,7 @@ import org.springframework.util.concurrent.ListenableFutureCallback;
  * @author Soby Chacko
  * @author Henryk Konsek
  * @author Doug Saus
+ * @author Rafal Zukowski
  */
 public class KafkaMessageChannelBinder extends
 		AbstractMessageChannelBinder<ExtendedConsumerProperties<KafkaConsumerProperties>, ExtendedProducerProperties<KafkaProducerProperties>, KafkaTopicProvisioner>


### PR DESCRIPTION
Hi, 
Can you tell me it his is is a good idea? 
Kafka producer has this very important value acks=all and it would be nice to use it.

What else should I do to have this merged? 