### PR TITLE
Change KafkaBinderMetrics to a tagged TimeGauge

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/KafkaBinderActuatorTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/KafkaBinderActuatorTests.java
@@ -74,15 +74,13 @@ public class KafkaBinderActuatorTests {
 
 	@Test
 	public void testKafkaBinderMetricsExposed() {
-		Search search = this.meterRegistry.find(
-				String.format("%s.%s.%s.lag", "spring.cloud.stream.binder.kafka", TEST_CONSUMER_GROUP, Sink.INPUT));
-
-		assertThat(search.gauge()).isNotNull();
-
 		this.kafkaTemplate.send(Sink.INPUT, null, "foo".getBytes());
 		this.kafkaTemplate.flush();
 
-		assertThat(search.gauge().value()).isGreaterThan(0);
+		assertThat(this.meterRegistry.get("spring.cloud.stream.binder.kafka.offset")
+				.tag("group", TEST_CONSUMER_GROUP)
+				.tag("topic", Sink.INPUT)
+				.timeGauge().value()).isGreaterThan(0);
 	}
 
 	@EnableBinding(Sink.class)


### PR DESCRIPTION
Using a `TimeGauge` rather than a plain gauge ensures that the value is scaled to a base unit of time that matches what each monitoring system expects.

I'm a little distressed by the [implementation](https://github.com/omkreddy/kafka-examples/blob/master/consumer/src/main/java/kafka/examples/consumer/processor/AsyncRecordProcessor.java#L58-L64) in Kafka, because it appears to use `System#currentTimeMillis` to arrive at a millisecond latency. `currentTimeMillis` is _not_ a monotonically increasing clock. It can actually move back/forward on NTP shifts or local time discontinuities. But oh well.

Also moved group and topic to tags.