### PR TITLE
GH-67: Reinstate resetOffsets property

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,8 @@ public class KafkaConsumerProperties {
 
 	private StartOffset startOffset;
 
+	private boolean resetOffsets;
+
 	private boolean enableDlq;
 
 	private String dlqName;
@@ -93,6 +95,14 @@ public class KafkaConsumerProperties {
 
 	public void setStartOffset(StartOffset startOffset) {
 		this.startOffset = startOffset;
+	}
+
+	public boolean isResetOffsets() {
+		return this.resetOffsets;
+	}
+
+	public void setResetOffsets(boolean resetOffsets) {
+		this.resetOffsets = resetOffsets;
 	}
 
 	public boolean isEnableDlq() {


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/67

Currently only supported with group management (`autoRebalanceEnabled` - default true).

See https://github.com/spring-projects/spring-kafka/issues/599