### PR TITLE
Event Publisher Polishing

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -371,8 +371,14 @@ public class KafkaMessageChannelBinder extends
 		};
 		messageListenerContainer.setConcurrency(concurrency);
 		// these won't be needed if the container is made a bean
-		messageListenerContainer.setApplicationEventPublisher(getApplicationContext());
+		if (getApplicationEventPublisher() != null) {
+			messageListenerContainer.setApplicationEventPublisher(getApplicationEventPublisher());
+		}
+		else if (getApplicationContext() != null) {
+			messageListenerContainer.setApplicationEventPublisher(getApplicationContext());
+		}
 		messageListenerContainer.setBeanName(destination.getName() + ".container");
+		// end of these won't be needed...
 		if (!extendedConsumerProperties.getExtension().isAutoCommitOffset()) {
 			messageListenerContainer.getContainerProperties()
 					.setAckMode(AbstractMessageListenerContainer.AckMode.MANUAL);


### PR DESCRIPTION
Now that the abstract binder makes its event publisher available to subclasses,
use it, if present, instead of the application context.
In most cases, they will be the same object, but the user might override the
publisher.