### PR TITLE
Allow state store creation when using process/transform method in DSL

### DIFF
--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/kafka-streams.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/kafka-streams.adoc
@@ -577,6 +577,38 @@ public KStream<?, WordCount> process(KStream<Object, String> input) {
 }
 ----
 
+== State Store
+
+State store is created automatically by Kafka Stream when Streas DSL is used. When use processor API, in case you want to
+create and register a state store manually, you can use `KafkaStreamsStateStore` annotation. You can specify store name,
+type, whether to enable log, whether disable cache, etc, and those parameters will be injected into KStream building
+process in Kafka Streams binder to create and register the store to your KStream. After that, you can access the same way
+how you access in normal Kafka Streams code.
+
+Creation code:
+[source]
+----
+@KafkaStreamsStateStore(name="mystate", type= KafkaStreamsStateStoreProperties.StoreType.WINDOW, lengthMs=300000)
+public void process(KStream<Object, Product> input) {
+    ...
+}
+----
+
+Access code:
+[source]
+----
+Processor<Object, Product>() {
+
+    WindowStore<Object, String> state;
+
+    @Override
+    public void init(ProcessorContext processorContext) {
+        state = (WindowStore)processorContext.getStateStore("mystate");
+    }
+    ...
+}
+----
+
 == Interactive Queries
 
 As part of the public Kafka Streams binder API, we expose a class called `QueryableStoreRegistry`. You can access this 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -84,6 +84,7 @@ import org.springframework.util.StringUtils;
  * 3. Each StreamListener method that it orchestrates gets its own {@link StreamsBuilderFactoryBean} and {@link StreamsConfig}
  *
  * @author Soby Chacko
+ * @author Lei Chen
  */
 class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListenerSetupMethodOrchestrator, ApplicationContextAware {
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -35,6 +35,9 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.state.KeyValueStore;
 
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -44,9 +47,11 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.binder.kafka.streams.annotations.KafkaStreamsStateStore;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
+import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsStateStoreProperties;
 import org.springframework.cloud.stream.binding.StreamListenerErrorMessages;
 import org.springframework.cloud.stream.binding.StreamListenerParameterAdapter;
 import org.springframework.cloud.stream.binding.StreamListenerResultAdapter;
@@ -230,10 +235,12 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListene
 					StreamsBuilderFactoryBean streamsBuilderFactoryBean = methodStreamsBuilderFactoryBeanMap.get(method);
 					StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
 					KafkaStreamsConsumerProperties extendedConsumerProperties = kafkaStreamsExtendedBindingProperties.getExtendedConsumerProperties(inboundName);
+					//get state store spec
+					KafkaStreamsStateStoreProperties spec = getStateStoreSpec(method);
 					Serde<?> keySerde = this.keyValueSerdeResolver.getInboundKeySerde(extendedConsumerProperties);
 					Serde<?> valueSerde = this.keyValueSerdeResolver.getInboundValueSerde(bindingProperties.getConsumer(), extendedConsumerProperties);
 					if (parameterType.isAssignableFrom(KStream.class)) {
-						KStream<?, ?> stream = getkStream(inboundName, bindingProperties, streamsBuilder, keySerde, valueSerde);
+						KStream<?, ?> stream = getkStream(inboundName, spec, bindingProperties, streamsBuilder, keySerde, valueSerde);
 						KStreamBoundElementFactory.KStreamWrapper kStreamWrapper = (KStreamBoundElementFactory.KStreamWrapper) targetBean;
 						//wrap the proxy created during the initial target type binding with real object (KStream)
 						kStreamWrapper.wrap((KStream<Object, Object>) stream);
@@ -288,8 +295,48 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListene
 						.withValueSerde(v));
 	}
 
-	private KStream<?, ?> getkStream(String inboundName, BindingProperties bindingProperties, StreamsBuilder streamsBuilder,
-									Serde<?> keySerde, Serde<?> valueSerde) {
+	private StoreBuilder buildStateStore(KafkaStreamsStateStoreProperties spec) throws Exception {
+		try {
+			Serde<?> keySerde = this.keyValueSerdeResolver.getStateStoreKeySerde(spec.getKeySerdeString());
+			Serde<?> valueSerde = this.keyValueSerdeResolver.getStateStoreValueSerde(spec.getValueSerdeString());
+			StoreBuilder builder = null;
+			switch (spec.getType()) {
+				case "keyvalue":
+					builder = Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore(spec.getName()), keySerde, valueSerde);
+					break;
+				case "window":
+					builder = Stores.windowStoreBuilder(Stores.persistentWindowStore(spec.getName(), spec.getRetention(), 3, spec.getSize(), false),
+							keySerde,
+							valueSerde);
+					break;
+				case "session":
+					builder = Stores.sessionStoreBuilder(Stores.persistentSessionStore(spec.getName(), spec.getRetention()), keySerde, valueSerde);
+					break;
+				default:
+					throw new UnsupportedOperationException("state store type (" + spec.getType() + ") is not supported!");
+			}
+			if (spec.isCacheEnabled())
+				builder = builder.withCachingEnabled();
+			if (spec.isLoggingDisabled())
+				builder = builder.withLoggingDisabled();
+
+			return builder;
+
+		}catch (Exception e) {
+			LOG.error("failed to build state store exception : " + e);
+			throw e;
+		}
+	}
+
+
+	private KStream<?, ?> getkStream(String inboundName, KafkaStreamsStateStoreProperties storeSpec, BindingProperties bindingProperties, StreamsBuilder streamsBuilder,
+									Serde<?> keySerde, Serde<?> valueSerde) throws Exception {
+		if (storeSpec != null) {
+			StoreBuilder storeBuilder = buildStateStore(storeSpec);
+			Assert.notNull(storeBuilder);
+			streamsBuilder.addStateStore(storeBuilder);
+			LOG.info("state store " + storeBuilder.name() + " added to topology");
+		}
 		KStream<?, ?> stream = streamsBuilder.stream(bindingServiceProperties.getBindingDestination(inboundName),
 				Consumed.with(keySerde, valueSerde));
 		final boolean nativeDecoding = bindingServiceProperties.getConsumerProperties(inboundName).isUseNativeDecoding();
@@ -428,6 +475,25 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListene
 			Assert.isTrue(!ObjectUtils.isEmpty(sendTo.value()), StreamListenerErrorMessages.ATLEAST_ONE_OUTPUT);
 			Assert.isTrue(sendTo.value().length >= 1, "At least one outbound destination need to be provided.");
 			return sendTo.value();
+		}
+		return null;
+	}
+
+	@SuppressWarnings({"unchecked"})
+	private static KafkaStreamsStateStoreProperties getStateStoreSpec(Method method) {
+		KafkaStreamsStateStore spec = AnnotationUtils.findAnnotation(method, KafkaStreamsStateStore.class);
+		if (spec != null) {
+			Assert.isTrue(!ObjectUtils.isEmpty(spec.name()), "name cannot be empty");
+			Assert.isTrue(spec.name().length() >= 1, "name cannot be empty.");
+			KafkaStreamsStateStoreProperties props = new KafkaStreamsStateStoreProperties();
+			props.setName(spec.name());
+			props.setType(spec.type());
+			props.setSize(spec.size());
+			props.setKeySerdeString(spec.keySerde());
+			props.setValueSerdeString(spec.valueSerde());
+			props.setCacheEnabled(spec.cache());
+			props.setLoggingDisabled(!spec.logging());
+			return props;
 		}
 		return null;
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -301,15 +301,15 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListene
 			Serde<?> valueSerde = this.keyValueSerdeResolver.getStateStoreValueSerde(spec.getValueSerdeString());
 			StoreBuilder builder = null;
 			switch (spec.getType()) {
-				case "keyvalue":
+				case KEYVALUE:
 					builder = Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore(spec.getName()), keySerde, valueSerde);
 					break;
-				case "window":
-					builder = Stores.windowStoreBuilder(Stores.persistentWindowStore(spec.getName(), spec.getRetention(), 3, spec.getSize(), false),
+				case WINDOW:
+					builder = Stores.windowStoreBuilder(Stores.persistentWindowStore(spec.getName(), spec.getRetention(), 3, spec.getLength(), false),
 							keySerde,
 							valueSerde);
 					break;
-				case "session":
+				case SESSION:
 					builder = Stores.sessionStoreBuilder(Stores.persistentSessionStore(spec.getName(), spec.getRetention()), keySerde, valueSerde);
 					break;
 				default:
@@ -488,8 +488,9 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListene
 			KafkaStreamsStateStoreProperties props = new KafkaStreamsStateStoreProperties();
 			props.setName(spec.name());
 			props.setType(spec.type());
-			props.setSize(spec.size());
+			props.setLength(spec.lengthMs());
 			props.setKeySerdeString(spec.keySerde());
+			props.setRetention(spec.retentionMs());
 			props.setValueSerdeString(spec.valueSerde());
 			props.setCacheEnabled(spec.cache());
 			props.setLoggingDisabled(!spec.logging());

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
@@ -38,10 +38,13 @@ import org.springframework.util.StringUtils;
  * If native decoding is disabled, then the binder will do the deserialization on value and ignore any Serde set for value
  * and rely on the contentType provided. Keys are always deserialized at the broker.
  *
+ *
  * Same rules apply on the outbound. If native encoding is enabled, then value serialization is done at the broker using
  * any binder level Serde for value, if not using common Serde, if not, then byte[].
  * If native encoding is disabled, then the binder will do serialization using a contentType. Keys are always serialized
  * by the broker.
+ *
+ * For state store, use serdes class specified in {@link KafkaStreamsStateStore} to create Serde accordingly.
  *
  * @author Soby Chacko
  */
@@ -123,6 +126,33 @@ class KeyValueSerdeResolver {
 				valueSerde = Serdes.ByteArray();
 			}
 			valueSerde.configure(streamConfigGlobalProperties, false);
+		}
+		catch (ClassNotFoundException e) {
+			throw new IllegalStateException("Serde class not found: ", e);
+		}
+		return valueSerde;
+	}
+
+	/**
+	 * Provide the {@link Serde} for state store
+	 *
+	 * @param keySerdeString serde class used for key
+	 * @return {@link Serde} for the state store key.
+	 */
+	public Serde<?> getStateStoreKeySerde(String keySerdeString) {
+		return getKeySerde(keySerdeString);
+	}
+
+	/**
+	 * Provide the {@link Serde} for state store value
+	 *
+	 * @param valueSerdeString serde class used for value
+	 * @return {@link Serde} for the state store value.
+	 */
+	public Serde<?> getStateStoreValueSerde(String valueSerdeString) {
+		Serde<?> valueSerde;
+		try {
+			valueSerde = getValueSerde(valueSerdeString);
 		}
 		catch (ClassNotFoundException e) {
 			throw new IllegalStateException("Serde class not found: ", e);

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
@@ -47,6 +47,7 @@ import org.springframework.util.StringUtils;
  * For state store, use serdes class specified in {@link KafkaStreamsStateStore} to create Serde accordingly.
  *
  * @author Soby Chacko
+ * @author Lei Chen
  */
 class KeyValueSerdeResolver {
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
@@ -1,4 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.stream.binder.kafka.streams.annotations;
 
-public interface KafkaStreamsStateStore {
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+
+public @interface KafkaStreamsStateStore {
+	String name() default "";
+
+	String type() default "keyvalue";
+
+	String keySerde() default "org.apache.kafka.common.serialization.Serdes$StringSerde";
+
+	String valueSerde() default "org.apache.kafka.common.serialization.Serdes$StringSerde";
+
+	long size() default 0;
+
+	long retention() default 0;
+
+	boolean cache() default false;
+
+	boolean logging() default true;
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
@@ -1,0 +1,4 @@
+package org.springframework.cloud.stream.binder.kafka.streams.annotations;
+
+public interface KafkaStreamsStateStore {
+}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
@@ -16,10 +16,13 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams.annotations;
 
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsStateStoreProperties;
 
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -27,15 +30,15 @@ import java.lang.annotation.Target;
 public @interface KafkaStreamsStateStore {
 	String name() default "";
 
-	String type() default "keyvalue";
+	KafkaStreamsStateStoreProperties.StoreType type() default KafkaStreamsStateStoreProperties.StoreType.KEYVALUE;
 
 	String keySerde() default "org.apache.kafka.common.serialization.Serdes$StringSerde";
 
 	String valueSerde() default "org.apache.kafka.common.serialization.Serdes$StringSerde";
 
-	long size() default 0;
+	long lengthMs() default 0;
 
-	long retention() default 0;
+	long retentionMs() default 0;
 
 	boolean cache() default false;
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
@@ -24,6 +24,40 @@ import java.lang.annotation.Target;
 
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsStateStoreProperties;
 
+
+/**
+ * Interface for Kafka Stream state store.
+ *
+ * This interface can be used to inject a state store specification into KStream building process so
+ * that the desired store can be built by StreamBuilder and added to topology for later use by processors.
+ * This is particularly useful when need to combine stream DSL with low level processor APIs. In those cases,
+ * if a writable state store is desired in processors, it needs to be created using this annotation.
+ * Here is the example.
+ *
+ * <pre class="code">
+ *     &#064;StreamListener("input")
+ *     &#064;KafkaStreamsStateStore(name="mystate", type= KafkaStreamsStateStoreProperties.StoreType.WINDOW, size=300000)
+ *	   public void process(KStream<Object, Product> input) {
+ *         ......
+ *     }
+ *</pre>
+ *
+ * With that, you should be able to read/write this state store in your processor/transformer code.
+ *
+ * <pre class="code">
+ * 		new Processor<Object, Product>() {
+ * 			WindowStore<Object, String> state;
+ * 			&#064;Override
+ *			public void init(ProcessorContext processorContext) {
+ *			state = (WindowStore)processorContext.getStateStore("mystate");
+ *				......
+ *			}
+ *		}
+ *</pre>
+ *
+ * @author Lei Chen
+ */
+
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/annotations/KafkaStreamsStateStore.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsStateStoreProperties;
+import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsStateStoreProperties;;
 
 
 /**
@@ -62,19 +62,44 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 @Retention(RetentionPolicy.RUNTIME)
 
 public @interface KafkaStreamsStateStore {
+
+	/**
+	 * @return name of state store.
+	 */
 	String name() default "";
 
+	/**
+	 * @return {@link KafkaStreamsStateStoreProperties.StoreType} of state store.
+	 */
 	KafkaStreamsStateStoreProperties.StoreType type() default KafkaStreamsStateStoreProperties.StoreType.KEYVALUE;
 
+	/**
+	 * @return key serde of state store.
+	 */
 	String keySerde() default "org.apache.kafka.common.serialization.Serdes$StringSerde";
 
+	/**
+	 * @return value serde of state store.
+	 */
 	String valueSerde() default "org.apache.kafka.common.serialization.Serdes$StringSerde";
 
+	/**
+	 * @return length in milli-second of window(for windowed store).
+	 */
 	long lengthMs() default 0;
 
+	/**
+	 * @return the maximum period of time in milli-second to keep each window in this store(for windowed store).
+	 */
 	long retentionMs() default 0;
 
+	/**
+	 * @return whether caching should be enabled on the created store.
+	 */
 	boolean cache() default false;
 
+	/**
+	 * @return whether logging should be enabled on the created store.
+	 */
 	boolean logging() default true;
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
@@ -1,0 +1,4 @@
+package org.springframework.cloud.stream.binder.kafka.streams.properties;
+
+public class KafkaStreamsStateStoreProperties {
+}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams.properties;
 
+
+/**
+ * @author Lei Chen
+ */
 public class KafkaStreamsStateStoreProperties {
 
 	public enum StoreType {

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
@@ -18,6 +18,28 @@ package org.springframework.cloud.stream.binder.kafka.streams.properties;
 
 public class KafkaStreamsStateStoreProperties {
 
+	public enum StoreType {
+		KEYVALUE("keyvalue"),
+		WINDOW("window"),
+		SESSION("session")
+		;
+
+		private final String type;
+
+		/**
+		 * @param type
+		 */
+		StoreType(final String type) {
+			this.type = type;
+		}
+
+		@Override
+		public String toString() {
+			return type;
+		}
+	}
+
+
 	/**
 	 * name for this state store
 	 */
@@ -26,15 +48,15 @@ public class KafkaStreamsStateStoreProperties {
 	/**
 	 * type for this state store
 	 */
-	private String type;
+	private StoreType type;
 
 	/**
-	 * Size/length of this state store. Only applicable for window store.
+	 * Size/length of this state store in ms. Only applicable for window store.
 	 */
-	private long size;
+	private long length;
 
 	/**
-	 * Retention period for this state store.
+	 * Retention period for this state store in ms.
 	 */
 	private long retention;
 
@@ -67,20 +89,20 @@ public class KafkaStreamsStateStoreProperties {
 		this.name = name;
 	}
 
-	public String getType() {
+	public StoreType getType() {
 		return type;
 	}
 
-	public void setType(String type) {
+	public void setType(StoreType type) {
 		this.type = type;
 	}
 
-	public long getSize() {
-		return size;
+	public long getLength() {
+		return length;
 	}
 
-	public void setSize(long size) {
-		this.size = size;
+	public void setLength(long length) {
+		this.length = length;
 	}
 
 	public long getRetention() {

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsStateStoreProperties.java
@@ -1,4 +1,125 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.stream.binder.kafka.streams.properties;
 
 public class KafkaStreamsStateStoreProperties {
+
+	/**
+	 * name for this state store
+	 */
+	private String name;
+
+	/**
+	 * type for this state store
+	 */
+	private String type;
+
+	/**
+	 * Size/length of this state store. Only applicable for window store.
+	 */
+	private long size;
+
+	/**
+	 * Retention period for this state store.
+	 */
+	private long retention;
+
+	/**
+	 * Key serde class specified per state store.
+	 */
+	private String keySerdeString;
+
+	/**
+	 * Value serde class specified per state store.
+	 */
+	private String valueSerdeString;
+
+	/**
+	 * Whether enable cache in this state store.
+	 */
+	private boolean cacheEnabled;
+
+	/**
+	 * Whether enable logging in this state store.
+	 */
+	private boolean loggingDisabled;
+
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public long getSize() {
+		return size;
+	}
+
+	public void setSize(long size) {
+		this.size = size;
+	}
+
+	public long getRetention() {
+		return retention;
+	}
+
+	public void setRetention(long retention) {
+		this.retention = retention;
+	}
+
+	public String getKeySerdeString() {
+		return keySerdeString;
+	}
+
+	public void setKeySerdeString(String keySerdeString) {
+		this.keySerdeString = keySerdeString;
+	}
+
+	public String getValueSerdeString() {
+		return valueSerdeString;
+	}
+
+	public void setValueSerdeString(String valueSerdeString) {
+		this.valueSerdeString = valueSerdeString;
+	}
+
+	public boolean isCacheEnabled() {
+		return cacheEnabled;
+	}
+
+	public void setCacheEnabled(boolean cacheEnabled) {
+		this.cacheEnabled = cacheEnabled;
+	}
+
+	public boolean isLoggingDisabled() {
+		return loggingDisabled;
+	}
+
+	public void setLoggingDisabled(boolean loggingDisabled) {
+		this.loggingDisabled = loggingDisabled;
+	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStateStoreIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStateStoreIntegrationTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.streams;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Serialized;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binder.kafka.streams.annotations.KafkaStreamsProcessor;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.serializer.JsonSerde;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.handler.annotation.SendTo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Soby Chacko
+ * @author Gary Russell
+ */
+public class KafkaStreamsInteractiveQueryIntegrationTests {
+
+	@ClassRule
+	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, "counts-id");
+
+	private static Consumer<String, String> consumer;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("group-id", "false", embeddedKafka);
+		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+		DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		consumer = cf.createConsumer();
+		embeddedKafka.consumeFromAnEmbeddedTopic(consumer, "counts-id");
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		consumer.close();
+	}
+
+	@Test
+	public void testKstreamBinderWithPojoInputAndStringOuput() throws Exception {
+		SpringApplication app = new SpringApplication(ProductCountApplication.class);
+		app.setWebApplicationType(WebApplicationType.NONE);
+		ConfigurableApplicationContext context = app.run("--server.port=0",
+				"--spring.jmx.enabled=false",
+				"--spring.cloud.stream.bindings.input.destination=foos",
+				"--spring.cloud.stream.bindings.output.destination=counts-id",
+				"--spring.cloud.stream.kafka.streams.binder.configuration.commit.interval.ms=1000",
+				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.bindings.output.producer.headerMode=raw",
+				"--spring.cloud.stream.bindings.input.consumer.headerMode=raw",
+				"--spring.cloud.stream.kafka.streams.binder.brokers=" + embeddedKafka.getBrokersAsString(),
+				"--spring.cloud.stream.kafka.streams.binder.zkNodes=" + embeddedKafka.getZookeeperConnectionString());
+		try {
+			receiveAndValidateFoo(context);
+		} finally {
+			context.close();
+		}
+	}
+
+	private void receiveAndValidateFoo(ConfigurableApplicationContext context) throws Exception {
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf, true);
+		template.setDefaultTopic("foos");
+		template.sendDefault("{\"id\":\"123\"}");
+		ConsumerRecord<String, String> cr = KafkaTestUtils.getSingleRecord(consumer, "counts-id");
+		assertThat(cr.value().contains("Count for product with ID 123: 1")).isTrue();
+
+		ProductCountApplication.Foo foo = context.getBean(ProductCountApplication.Foo.class);
+		assertThat(foo.getProductStock(123).equals(1L));
+	}
+
+	@EnableBinding(KafkaStreamsProcessor.class)
+	@EnableAutoConfiguration
+	public static class ProductCountApplication {
+
+		@Autowired
+		private QueryableStoreRegistry queryableStoreRegistry;
+
+		@StreamListener("input")
+		@SendTo("output")
+		@SuppressWarnings("deprecation")
+		public KStream<?, String> process(KStream<Object, Product> input) {
+
+			return input
+					.filter((key, product) -> product.getId() == 123)
+					.map((key, value) -> new KeyValue<>(value.id, value))
+					.groupByKey(Serialized.with(new Serdes.IntegerSerde(), new JsonSerde<>(Product.class)))
+					.count("prod-id-count-store")
+					.toStream()
+					.map((key, value) -> new KeyValue<>(null, "Count for product with ID 123: " + value));
+		}
+
+		@Bean
+		public Foo foo(QueryableStoreRegistry queryableStoreRegistry) {
+			return new Foo(queryableStoreRegistry);
+		}
+
+		static class Foo {
+			QueryableStoreRegistry queryableStoreRegistry;
+
+			Foo(QueryableStoreRegistry queryableStoreRegistry) {
+				this.queryableStoreRegistry = queryableStoreRegistry;
+			}
+
+			public Long getProductStock(Integer id) {
+				ReadOnlyKeyValueStore<Object, Object> keyValueStore =
+						queryableStoreRegistry.getQueryableStoreType("prod-id-count-store", QueryableStoreTypes.keyValueStore());
+				return (Long) keyValueStore.get(id);
+			}
+		}
+	}
+
+	static class Product {
+
+		Integer id;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+	}
+}

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStateStoreIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStateStoreIntegrationTests.java
@@ -37,6 +37,7 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.binder.kafka.streams.annotations.KafkaStreamsStateStore;
+import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsStateStoreProperties;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -106,7 +107,7 @@ public class KafkaStreamsStateStoreIntegrationTests {
 	public static class ProductCountApplication {
 
 		@StreamListener("input")
-		@KafkaStreamsStateStore(name="mystate", type="window", size=300000)
+		@KafkaStreamsStateStore(name="mystate", type= KafkaStreamsStateStoreProperties.StoreType.WINDOW, size=300000)
 		@SuppressWarnings("deprecation")
 		public void process(KStream<Object, Product> input) {
 			input

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStateStoreIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStateStoreIntegrationTests.java
@@ -47,6 +47,9 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * @author Lei Chen
+ */
 public class KafkaStreamsStateStoreIntegrationTests {
 
 	@ClassRule
@@ -107,7 +110,7 @@ public class KafkaStreamsStateStoreIntegrationTests {
 	public static class ProductCountApplication {
 
 		@StreamListener("input")
-		@KafkaStreamsStateStore(name="mystate", type= KafkaStreamsStateStoreProperties.StoreType.WINDOW, size=300000)
+		@KafkaStreamsStateStore(name="mystate", type= KafkaStreamsStateStoreProperties.StoreType.WINDOW, lengthMs=300000)
 		@SuppressWarnings("deprecation")
 		public void process(KStream<Object, Product> input) {
 			input


### PR DESCRIPTION
This is to allow state store creation when using process/transform method in DSL, as discussed issue [340](https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/340#issuecomment-374389992).

By implementing a new annotation, developers can use below code to create a state store and inject to KStream topology so it can be later used in processor or transformer code.
@KafkaStreamsStateStore(name="mystate", type="window", size=300000)

@sobychacko 