### PR TITLE
Address IllegalAccessException in Kafka Streams binder

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -66,6 +66,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -155,6 +156,7 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListene
 				this.applicationContext,
 				this.streamListenerParameterAdapter);
 		try {
+			ReflectionUtils.makeAccessible(method);
 			if (Void.TYPE.equals(method.getReturnType())) {
 				method.invoke(bean, adaptedInboundArguments);
 			}

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderWordCountIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderWordCountIntegrationTests.java
@@ -119,7 +119,7 @@ public class KafkaStreamsBinderWordCountIntegrationTests {
 	@EnableBinding(KafkaStreamsProcessor.class)
 	@EnableAutoConfiguration
 	@EnableConfigurationProperties(KafkaStreamsApplicationSupportProperties.class)
-	public static class WordCountProcessorApplication {
+	static class WordCountProcessorApplication {
 
 		@Autowired
 		private TimeWindows timeWindows;


### PR DESCRIPTION
When StreamListener methods are contained in a top level non-public class, Kafka
Streams binder throws an IllegalAccessException. Fixing it by making it accessible.

Resolves #348