### PR TITLE
Enhance the error message headers before sending to DLQ only for consumer with embedded header mode

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -45,6 +45,7 @@ import org.springframework.cloud.stream.binder.EmbeddedHeaderUtils;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
+import org.springframework.cloud.stream.binder.HeaderMode;
 import org.springframework.cloud.stream.binder.MessageValues;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
@@ -359,7 +360,8 @@ public class KafkaMessageChannelBinder extends
 							? Utils.toArray(ByteBuffer.wrap((byte[]) record.key()))
 							: null;
 					final byte[] payload;
-					if (message.getPayload() instanceof Throwable) {
+					if (HeaderMode.embeddedHeaders == extendedConsumerProperties.getHeaderMode()
+							&& message.getPayload() instanceof Throwable) {
 						final Throwable throwable = (Throwable) message.getPayload();
 						final String failureMessage = throwable.getMessage();
 


### PR DESCRIPTION
This is a small fix to prevent enhancing the error message before sending to `DLQ` in case of a consumer with raw header mode.