### PR TITLE
Fixed the https://github.com/spring-cloud/spring-cloud-stream/issues/…

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/QueryableStoreRegistry.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/QueryableStoreRegistry.java
@@ -18,8 +18,10 @@ package org.springframework.cloud.stream.binder.kafka.streams;
 
 import java.util.HashSet;
 import java.util.Set;
-
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.QueryableStoreType;
 
 /**
@@ -30,6 +32,7 @@ import org.apache.kafka.streams.state.QueryableStoreType;
  * @since 2.0.0
  */
 public class QueryableStoreRegistry {
+	private final Log logger = LogFactory.getLog(getClass());
 
 	private final Set<KafkaStreams> kafkaStreams = new HashSet<>();
 
@@ -44,9 +47,14 @@ public class QueryableStoreRegistry {
 	public <T> T getQueryableStoreType(String storeName, QueryableStoreType<T> storeType) {
 
 		for (KafkaStreams kafkaStream : kafkaStreams) {
+			try{
 			T store = kafkaStream.store(storeName, storeType);
 			if (store != null) {
 				return store;
+			}
+			}
+			catch (InvalidStateStoreException ignored) {
+				//pass through
 			}
 		}
 		return null;


### PR DESCRIPTION
Add exception to pass through to fix the issue.
```
public <T> T getQueryableStoreType(String storeName, QueryableStoreType<T> storeType) {

		for (KafkaStreams kafkaStream : kafkaStreams) {
			try{
			T store = kafkaStream.store(storeName, storeType);
			if (store != null) {
				return store;
			}
			}
			catch (InvalidStateStoreException ignored) {
				//pass through
			}
		}
		return null;
	}
```