### PR TITLE
GH-339: Support topic patterns

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
@@ -81,6 +81,8 @@ public class KafkaConsumerProperties {
 
 	private long idleEventInterval = 30_000;
 
+	private boolean destinationIsPattern;
+
 	private Map<String, String> configuration = new HashMap<>();
 
 	private KafkaAdminProperties admin = new KafkaAdminProperties();
@@ -214,6 +216,14 @@ public class KafkaConsumerProperties {
 
 	public void setIdleEventInterval(long idleEventInterval) {
 		this.idleEventInterval = idleEventInterval;
+	}
+
+	public boolean isDestinationIsPattern() {
+		return this.destinationIsPattern;
+	}
+
+	public void setDestinationIsPattern(boolean destinationIsPattern) {
+		this.destinationIsPattern = destinationIsPattern;
 	}
 
 	public KafkaAdminProperties getAdmin() {

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
@@ -152,6 +152,15 @@ public class KafkaTopicProvisioner implements ProvisioningProvider<ExtendedConsu
 	public ConsumerDestination provisionConsumerDestination(final String name, final String group,
 			ExtendedConsumerProperties<KafkaConsumerProperties> properties) {
 
+		if (properties.getExtension().isDestinationIsPattern()) {
+			Assert.isTrue(!properties.getExtension().isEnableDlq(),
+					"enableDLQ is not allowed when listening to topic patterns");
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("Listening to a topic pattern - " + name
+						+ " - no provisioning performed");
+			}
+			return new KafkaConsumerDestination(name);
+		}
 		KafkaTopicUtils.validateTopicName(name);
 		boolean anonymous = !StringUtils.hasText(group);
 		Assert.isTrue(!anonymous || !properties.getExtension().isEnableDlq(),

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -207,6 +207,7 @@ The DLQ topic name can be configurable by setting the `dlqName` property.
 This provides an alternative option to the more common Kafka replay scenario for the case when the number of errors is relatively small and replaying the entire original topic may be too cumbersome.
 See <<kafka-dlq-processing>> processing for more information.
 Starting with version 2.0, messages sent to the DLQ topic are enhanced with the following headers: `x-original-topic`, `x-exception-message`, and `x-exception-stacktrace` as `byte[]`.
+**Not allowed when `destinationIsPattern` is `true`.**
 +
 Default: `false`.
 configuration::
@@ -238,6 +239,11 @@ Use an `ApplicationListener<ListenerContainerIdleEvent>` to receive these events
 See <<pause-resume>> for a usage example.
 +
 Default: `30000`
+destinationIsPattern::
+When true, the destination is treated as a regular expression `Pattern` used to match topic names by the broker.
+When true, topics are not provisioned, and `enableDlq` is not allowed, because the binder does not know the topic names during the provisioning phase.
++
+Default: `false`
 
 [[kafka-producer-properties]]
 === Kafka Producer Properties

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/overview.adoc
@@ -242,6 +242,8 @@ Default: `30000`
 destinationIsPattern::
 When true, the destination is treated as a regular expression `Pattern` used to match topic names by the broker.
 When true, topics are not provisioned, and `enableDlq` is not allowed, because the binder does not know the topic names during the provisioning phase.
+Note, the time taken to detect new topics that match the pattern is controlled by the consumer property `metadata.max.age.ms`, which (at the time of writing) defaults to 300,000ms (5 minutes).
+This can be configured using the `configuration` property above.
 +
 Default: `false`
 


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/339

- support regex patterns for consumer destinations to consume from multiple topics
- `enableDlq` is not available in this mode

As well as the test case, tested with a boot app...

```
spring.cloud.stream.bindings.input.destination=kbgh339.*
spring.cloud.stream.kafka.bindings.input.consumer.destination-is-pattern=true
```

and

```
2018-04-30 15:12:49.718  : partitions assigned: [kbgh339a-0]
2018-04-30 15:17:46.585  : partitions revoked: [kbgh339a-0]
2018-04-30 15:17:46.655  : partitions assigned: [kbgh339a-0, kbgh339b-0]
```

after adding a new topic matching the pattern.