### PR TITLE
GH-373: Support multiplexed consumers

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
@@ -151,6 +151,20 @@ public class KafkaTopicProvisioner implements ProvisioningProvider<ExtendedConsu
 	@Override
 	public ConsumerDestination provisionConsumerDestination(final String name, final String group,
 			ExtendedConsumerProperties<KafkaConsumerProperties> properties) {
+		if (!properties.isMultiplex()) {
+			return doProvisionConsumerDestination(name, group, properties);
+		}
+		else {
+			String[] destinations = StringUtils.commaDelimitedListToStringArray(name);
+			for (String destination : destinations) {
+				doProvisionConsumerDestination(destination.trim(), group, properties);
+			}
+			return new KafkaConsumerDestination(name);
+		}
+	}
+
+	private ConsumerDestination doProvisionConsumerDestination(final String name, final String group,
+			ExtendedConsumerProperties<KafkaConsumerProperties> properties) {
 
 		if (properties.getExtension().isDestinationIsPattern()) {
 			Assert.isTrue(!properties.getExtension().isEnableDlq(),


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/373

When a consumer is multiplexed, configure the container to listen to multiple topics.
Also for the polled consumer.

When using a DLQ, determine the queue name from the topic in the failed record (unless
an explicit DLQ name has been provisioned - in which case, the same DLQ will be used
for all topics.