### PR TITLE
GH-404: Synchronize shared consumer

### DIFF
--- a/spring-cloud-stream-binder-kafka/.settings/org.eclipse.jdt.ui.prefs
+++ b/spring-cloud-stream-binder-kafka/.settings/org.eclipse.jdt.ui.prefs
@@ -1,5 +1,5 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.ui.ignorelowercasenames=true
-org.eclipse.jdt.ui.importorder=java;javax;com;org;org.springframework;ch.qos;\#;
+org.eclipse.jdt.ui.importorder=java;javax;com;io.micrometer;org;org.springframework;ch.qos;\#;
 org.eclipse.jdt.ui.ondemandthreshold=99
 org.eclipse.jdt.ui.staticondemandthreshold=99


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/404

The fix for issue https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/231
added a shared consumer but the consumer is not thread safe. Add synchronization.

Also, a timeout was added to the `KafkaBinderHealthIndicator` but not to the
`KafkaBinderMetrics` which has a similar shared consumer; add a timeout there.

**suggestion reviewing PR with `?w=1` on URL - most changes are indentation**

**cherry-pick to 2.0.x**