### PR TITLE
Address deprecations in Kafka Streams binder

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.Map;
+
 import org.apache.kafka.streams.kstream.GlobalKTable;
 
 import org.springframework.cloud.stream.binder.AbstractBinder;
@@ -49,15 +51,15 @@ public class GlobalKTableBinder extends
 
 	private final KafkaTopicProvisioner kafkaTopicProvisioner;
 
-	private final KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue;
+	private final Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers;
 
 	private KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties = new KafkaStreamsExtendedBindingProperties();
 
 	public GlobalKTableBinder(KafkaStreamsBinderConfigurationProperties binderConfigurationProperties, KafkaTopicProvisioner kafkaTopicProvisioner,
-				KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue) {
+							  Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers) {
 		this.binderConfigurationProperties = binderConfigurationProperties;
 		this.kafkaTopicProvisioner = kafkaTopicProvisioner;
-		this.kafkaStreamsBindingInformationCatalogue = kafkaStreamsBindingInformationCatalogue;
+		this.kafkaStreamsDlqDispatchers = kafkaStreamsDlqDispatchers;
 	}
 
 	@Override
@@ -67,11 +69,9 @@ public class GlobalKTableBinder extends
 		if (!StringUtils.hasText(group)) {
 			group = binderConfigurationProperties.getApplicationId();
 		}
-		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group, inputTarget,
-				getApplicationContext(),
+		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group, getApplicationContext(),
 				kafkaTopicProvisioner,
-				kafkaStreamsBindingInformationCatalogue,
-				binderConfigurationProperties, properties);
+				binderConfigurationProperties, properties, kafkaStreamsDlqDispatchers);
 		return new DefaultBinding<>(name, group, inputTarget, null);
 	}
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinderConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner;
@@ -41,8 +44,7 @@ public class GlobalKTableBinderConfiguration {
 	@Bean
 	public GlobalKTableBinder GlobalKTableBinder(KafkaStreamsBinderConfigurationProperties binderConfigurationProperties,
 									KafkaTopicProvisioner kafkaTopicProvisioner,
-									KafkaStreamsBindingInformationCatalogue KafkaStreamsBindingInformationCatalogue) {
-		return new GlobalKTableBinder(binderConfigurationProperties, kafkaTopicProvisioner,
-				KafkaStreamsBindingInformationCatalogue);
+									@Qualifier("kafkaStreamsDlqDispatchers") Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers) {
+		return new GlobalKTableBinder(binderConfigurationProperties, kafkaTopicProvisioner, kafkaStreamsDlqDispatchers);
 	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.Map;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.common.serialization.Serde;
@@ -64,16 +66,20 @@ class KStreamBinder extends
 
 	private final KeyValueSerdeResolver keyValueSerdeResolver;
 
+	private final Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers;
+
 	KStreamBinder(KafkaStreamsBinderConfigurationProperties binderConfigurationProperties,
 				KafkaTopicProvisioner kafkaTopicProvisioner,
 				KafkaStreamsMessageConversionDelegate kafkaStreamsMessageConversionDelegate,
 				KafkaStreamsBindingInformationCatalogue KafkaStreamsBindingInformationCatalogue,
-				KeyValueSerdeResolver keyValueSerdeResolver) {
+				KeyValueSerdeResolver keyValueSerdeResolver,
+				  Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers) {
 		this.binderConfigurationProperties = binderConfigurationProperties;
 		this.kafkaTopicProvisioner = kafkaTopicProvisioner;
 		this.kafkaStreamsMessageConversionDelegate = kafkaStreamsMessageConversionDelegate;
 		this.kafkaStreamsBindingInformationCatalogue = KafkaStreamsBindingInformationCatalogue;
 		this.keyValueSerdeResolver = keyValueSerdeResolver;
+		this.kafkaStreamsDlqDispatchers = kafkaStreamsDlqDispatchers;
 	}
 
 	@Override
@@ -85,11 +91,9 @@ class KStreamBinder extends
 		if (!StringUtils.hasText(group)) {
 			group = binderConfigurationProperties.getApplicationId();
 		}
-		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group, inputTarget,
-				getApplicationContext(),
+		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group, getApplicationContext(),
 				kafkaTopicProvisioner,
-				kafkaStreamsBindingInformationCatalogue,
-				binderConfigurationProperties, properties);
+				binderConfigurationProperties, properties, kafkaStreamsDlqDispatchers);
 
 		return new DefaultBinding<>(name, group, inputTarget, null);
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinderConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.MethodInvokingFactoryBean;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -86,14 +89,15 @@ public class KStreamBinderConfiguration {
 
 	@Bean
 	public KStreamBinder kStreamBinder(KafkaStreamsBinderConfigurationProperties binderConfigurationProperties,
-									KafkaTopicProvisioner kafkaTopicProvisioner,
-									KafkaStreamsMessageConversionDelegate KafkaStreamsMessageConversionDelegate,
-									KafkaStreamsBindingInformationCatalogue KafkaStreamsBindingInformationCatalogue,
-									KeyValueSerdeResolver keyValueSerdeResolver,
-									KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties) {
+									   KafkaTopicProvisioner kafkaTopicProvisioner,
+									   KafkaStreamsMessageConversionDelegate KafkaStreamsMessageConversionDelegate,
+									   KafkaStreamsBindingInformationCatalogue KafkaStreamsBindingInformationCatalogue,
+									   KeyValueSerdeResolver keyValueSerdeResolver,
+									   KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties,
+									   @Qualifier("kafkaStreamsDlqDispatchers") Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers) {
 		KStreamBinder kStreamBinder = new KStreamBinder(binderConfigurationProperties, kafkaTopicProvisioner,
 				KafkaStreamsMessageConversionDelegate, KafkaStreamsBindingInformationCatalogue,
-				keyValueSerdeResolver);
+				keyValueSerdeResolver, kafkaStreamsDlqDispatchers);
 		kStreamBinder.setKafkaStreamsExtendedBindingProperties(kafkaStreamsExtendedBindingProperties);
 		return kStreamBinder;
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.Map;
+
 import org.apache.kafka.streams.kstream.KTable;
 
 import org.springframework.cloud.stream.binder.AbstractBinder;
@@ -48,15 +50,15 @@ class KTableBinder extends
 
 	private final KafkaTopicProvisioner kafkaTopicProvisioner;
 
-	private final KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue;
+	private Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers;
 
 	private KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties = new KafkaStreamsExtendedBindingProperties();
 
 	KTableBinder(KafkaStreamsBinderConfigurationProperties binderConfigurationProperties, KafkaTopicProvisioner kafkaTopicProvisioner,
-						KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue) {
+				 Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers) {
 		this.binderConfigurationProperties = binderConfigurationProperties;
 		this.kafkaTopicProvisioner = kafkaTopicProvisioner;
-		this.kafkaStreamsBindingInformationCatalogue = kafkaStreamsBindingInformationCatalogue;
+		this.kafkaStreamsDlqDispatchers = kafkaStreamsDlqDispatchers;
 	}
 
 	@Override
@@ -66,11 +68,9 @@ class KTableBinder extends
 		if (!StringUtils.hasText(group)) {
 			group = binderConfigurationProperties.getApplicationId();
 		}
-		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group, inputTarget,
-				getApplicationContext(),
+		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group, getApplicationContext(),
 				kafkaTopicProvisioner,
-				kafkaStreamsBindingInformationCatalogue,
-				binderConfigurationProperties, properties);
+				binderConfigurationProperties, properties, kafkaStreamsDlqDispatchers);
 		return new DefaultBinding<>(name, group, inputTarget, null);
 	}
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinderConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -56,9 +59,8 @@ public class KTableBinderConfiguration {
 	@Bean
 	public KTableBinder kTableBinder(KafkaStreamsBinderConfigurationProperties binderConfigurationProperties,
 									KafkaTopicProvisioner kafkaTopicProvisioner,
-									KafkaStreamsBindingInformationCatalogue KafkaStreamsBindingInformationCatalogue) {
-		KTableBinder kStreamBinder = new KTableBinder(binderConfigurationProperties, kafkaTopicProvisioner,
-				KafkaStreamsBindingInformationCatalogue);
+									 @Qualifier("kafkaStreamsDlqDispatchers") Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers) {
+		KTableBinder kStreamBinder = new KTableBinder(binderConfigurationProperties, kafkaTopicProvisioner, kafkaStreamsDlqDispatchers);
 		return kStreamBinder;
 	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.stream.binder.kafka.streams;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -109,13 +110,13 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 
 		if (binderConfigurationProperties.getSerdeError() == KafkaStreamsBinderConfigurationProperties.SerdeError.logAndContinue) {
 			properties.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
-					LogAndContinueExceptionHandler.class);
+					LogAndContinueExceptionHandler.class.getName());
 		} else if (binderConfigurationProperties.getSerdeError() == KafkaStreamsBinderConfigurationProperties.SerdeError.logAndFail) {
 			properties.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
-					LogAndFailExceptionHandler.class);
+					LogAndFailExceptionHandler.class.getName());
 		} else if (binderConfigurationProperties.getSerdeError() == KafkaStreamsBinderConfigurationProperties.SerdeError.sendToDlq) {
 			properties.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
-					SendToDlqAndContinue.class);
+					SendToDlqAndContinue.class.getName());
 		}
 
 		if (!ObjectUtils.isEmpty(binderConfigurationProperties.getConfiguration())) {
@@ -144,11 +145,10 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 			KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue,
 			KStreamStreamListenerParameterAdapter kafkaStreamListenerParameterAdapter,
 			Collection<StreamListenerResultAdapter> streamListenerResultAdapters,
-			KafkaStreamsBinderConfigurationProperties binderConfigurationProperties,
 			ObjectProvider<CleanupConfig> cleanupConfig) {
 		return new KafkaStreamsStreamListenerSetupMethodOrchestrator(bindingServiceProperties,
 				kafkaStreamsExtendedBindingProperties, keyValueSerdeResolver, kafkaStreamsBindingInformationCatalogue,
-				kafkaStreamListenerParameterAdapter, streamListenerResultAdapters, binderConfigurationProperties,
+				kafkaStreamListenerParameterAdapter, streamListenerResultAdapters,
 				cleanupConfig.getIfUnique());
 	}
 
@@ -215,6 +215,11 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 	public StreamsBuilderFactoryManager streamsBuilderFactoryManager(KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue,
 																	KafkaStreamsRegistry kafkaStreamsRegistry) {
 		return new StreamsBuilderFactoryManager(kafkaStreamsBindingInformationCatalogue, kafkaStreamsRegistry);
+	}
+
+	@Bean("kafkaStreamsDlqDispatchers")
+	public Map<String, KafkaStreamsDlqDispatch> dlqDispatchers() {
+		return new HashMap<>();
 	}
 
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -43,8 +43,6 @@ class KafkaStreamsBindingInformationCatalogue {
 
 	private final Map<KStream<?, ?>, KafkaStreamsConsumerProperties> consumerProperties = new ConcurrentHashMap<>();
 
-	private final Map<Object, StreamsConfig> streamsConfigs = new ConcurrentHashMap<>();
-
 	private final Set<StreamsBuilderFactoryBean> streamsBuilderFactoryBeans = new HashSet<>();
 
 	/**
@@ -95,16 +93,6 @@ class KafkaStreamsBindingInformationCatalogue {
 	}
 
 	/**
-	 * Retrieve and return the registered {@link StreamsBuilderFactoryBean} for the given KStream
-	 *
-	 * @param bindingTarget KStream binding target
-	 * @return corresponding {@link StreamsBuilderFactoryBean}
-	 */
-	StreamsConfig getStreamsConfig(Object bindingTarget) {
-		return streamsConfigs.get(bindingTarget);
-	}
-
-	/**
 	 * Register a cache for bounded KStream -> {@link BindingProperties}
 	 *
 	 * @param bindingTarget KStream binding target
@@ -131,10 +119,6 @@ class KafkaStreamsBindingInformationCatalogue {
 	 */
 	void addStreamBuilderFactory(StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
 		this.streamsBuilderFactoryBeans.add(streamsBuilderFactoryBean);
-	}
-
-	void addStreamsConfigs(Object bindingTarget, StreamsConfig streamsConfig) {
-		this.streamsConfigs.put(bindingTarget, streamsConfig);
 	}
 
 	Set<StreamsBuilderFactoryBean> getStreamsBuilderFactoryBeans() {


### PR DESCRIPTION
* Remove the use of deprecated constructors in StreamsBuilderFactoryBean.
* Remove direct usage of StreamsConfig in favor of KafkaStreamsConfiguration.
* Change the way DLQ sending objects are provided to StreamsConfig since
  the binder does not directly deal with StreamsConfig any longer.
* Refactoring and polishing.

Resolves #442