### PR TITLE
Kafka Health Indicator changes

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderHealthIndicatorConfiguration.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderHealthIndicatorConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.stream.binder.kafka.KafkaBinderHealthIndicator;
 import org.springframework.cloud.stream.binder.kafka.KafkaMessageChannelBinder;
@@ -40,11 +41,12 @@ import org.springframework.util.ObjectUtils;
 
 @Configuration
 @ConditionalOnClass(name="org.springframework.boot.actuate.health.HealthIndicator")
+@ConditionalOnEnabledHealthIndicator("binders")
 class KafkaBinderHealthIndicatorConfiguration {
 
 	@Bean
-	KafkaBinderHealthIndicator healthIndicator(KafkaMessageChannelBinder kafkaMessageChannelBinder,
-											KafkaBinderConfigurationProperties configurationProperties) {
+	KafkaBinderHealthIndicator kafkaBinderHealthIndicator(KafkaMessageChannelBinder kafkaMessageChannelBinder,
+														  KafkaBinderConfigurationProperties configurationProperties) {
 		Map<String, Object> props = new HashMap<>();
 		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
 		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);


### PR DESCRIPTION
Disable Kafka health indicator check if management.health.binders.enabled
property is set to false. Currently, if this property is disabled, only the
core spring-cloud-stream mechanism of collecting the health checks are disabled.
The indivividual binders can still register the health check bean and boot health
actuator will still pick it up. If the user turns off health check by disabling
this property, then the stream app should completely disable any binder specific
health check.

Resolves #454