### PR TITLE
Regex topics in health indicator

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -255,7 +255,7 @@ public class KafkaMessageChannelBinder extends
 					((DisposableBean) producerFB).destroy();
 					return partitionsFor;
 				});
-		this.topicsInUse.put(destination.getName(), new TopicInformation(null, partitions));
+		this.topicsInUse.put(destination.getName(), new TopicInformation(null, partitions, false));
 		if (producerProperties.isPartitioned() && producerProperties.getPartitionCount() < partitions.size()) {
 			if (this.logger.isInfoEnabled()) {
 				this.logger.info("The `partitionCount` of the producer for topic " + destination.getName() + " is "
@@ -488,7 +488,7 @@ public class KafkaMessageChannelBinder extends
 				}
 			}
 		}
-		this.topicsInUse.put(topic, new TopicInformation(group, listenedPartitions));
+		this.topicsInUse.put(topic, new TopicInformation(group, listenedPartitions, usingPatterns));
 		return listenedPartitions;
 	}
 
@@ -567,13 +567,13 @@ public class KafkaMessageChannelBinder extends
 			// not just the ones this binding is listening to; doesn't seem right for a health check.
 			Collection<PartitionInfo> partitionInfos = getPartitionInfo(destination.getName(), consumerProperties,
 					consumerFactory, -1);
-			this.topicsInUse.put(destination.getName(), new TopicInformation(group, partitionInfos));
+			this.topicsInUse.put(destination.getName(), new TopicInformation(group, partitionInfos, false));
 		}
 		else {
 			for (int i = 0; i < topics.length; i++) {
 				Collection<PartitionInfo> partitionInfos = getPartitionInfo(topics[i], consumerProperties,
 						consumerFactory, -1);
-				this.topicsInUse.put(topics[i], new TopicInformation(group, partitionInfos));
+				this.topicsInUse.put(topics[i], new TopicInformation(group, partitionInfos, false));
 			}
 		}
 
@@ -938,9 +938,12 @@ public class KafkaMessageChannelBinder extends
 
 		private final Collection<PartitionInfo> partitionInfos;
 
-		TopicInformation(String consumerGroup, Collection<PartitionInfo> partitionInfos) {
+		private final boolean isTopicPattern;
+
+		TopicInformation(String consumerGroup, Collection<PartitionInfo> partitionInfos, boolean isTopicPattern) {
 			this.consumerGroup = consumerGroup;
 			this.partitionInfos = partitionInfos;
+			this.isTopicPattern = isTopicPattern;
 		}
 
 		String getConsumerGroup() {
@@ -949,6 +952,10 @@ public class KafkaMessageChannelBinder extends
 
 		boolean isConsumerTopic() {
 			return consumerGroup != null;
+		}
+
+		boolean isTopicPattern() {
+			return isTopicPattern;
 		}
 
 		Collection<PartitionInfo> getPartitionInfos() {

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Henryk Konsek
  * @author Thomas Cheyney
+ * @author Soby Chacko
  */
 public class KafkaBinderMetricsTest {
 
@@ -83,7 +84,7 @@ public class KafkaBinderMetricsTest {
 	public void shouldIndicateLag() {
 		org.mockito.BDDMockito.given(consumer.committed(ArgumentMatchers.any(TopicPartition.class))).willReturn(new OffsetAndMetadata(500));
 		List<PartitionInfo> partitions = partitions(new Node(0, null, 0));
-		topicsInUse.put(TEST_TOPIC, new TopicInformation("group1-metrics", partitions));
+		topicsInUse.put(TEST_TOPIC, new TopicInformation("group1-metrics", partitions, false));
 		org.mockito.BDDMockito.given(consumer.partitionsFor(TEST_TOPIC)).willReturn(partitions);
 		metrics.bindTo(meterRegistry);
 		assertThat(meterRegistry.getMeters()).hasSize(1);
@@ -99,7 +100,7 @@ public class KafkaBinderMetricsTest {
 		org.mockito.BDDMockito.given(consumer.endOffsets(ArgumentMatchers.anyCollection())).willReturn(endOffsets);
 		org.mockito.BDDMockito.given(consumer.committed(ArgumentMatchers.any(TopicPartition.class))).willReturn(new OffsetAndMetadata(500));
 		List<PartitionInfo> partitions = partitions(new Node(0, null, 0), new Node(0, null, 0));
-		topicsInUse.put(TEST_TOPIC, new TopicInformation("group2-metrics", partitions));
+		topicsInUse.put(TEST_TOPIC, new TopicInformation("group2-metrics", partitions, false));
 		org.mockito.BDDMockito.given(consumer.partitionsFor(TEST_TOPIC)).willReturn(partitions);
 		metrics.bindTo(meterRegistry);
 		assertThat(meterRegistry.getMeters()).hasSize(1);
@@ -110,7 +111,7 @@ public class KafkaBinderMetricsTest {
 	@Test
 	public void shouldIndicateFullLagForNotCommittedGroups() {
 		List<PartitionInfo> partitions = partitions(new Node(0, null, 0));
-		topicsInUse.put(TEST_TOPIC, new TopicInformation("group3-metrics", partitions));
+		topicsInUse.put(TEST_TOPIC, new TopicInformation("group3-metrics", partitions, false));
 		org.mockito.BDDMockito.given(consumer.partitionsFor(TEST_TOPIC)).willReturn(partitions);
 		metrics.bindTo(meterRegistry);
 		assertThat(meterRegistry.getMeters()).hasSize(1);
@@ -121,7 +122,7 @@ public class KafkaBinderMetricsTest {
 	@Test
 	public void shouldNotCalculateLagForProducerTopics() {
 		List<PartitionInfo> partitions = partitions(new Node(0, null, 0));
-		topicsInUse.put(TEST_TOPIC, new TopicInformation(null, partitions));
+		topicsInUse.put(TEST_TOPIC, new TopicInformation(null, partitions, false));
 		metrics.bindTo(meterRegistry);
 		assertThat(meterRegistry.getMeters()).isEmpty();
 	}
@@ -129,7 +130,7 @@ public class KafkaBinderMetricsTest {
 	@Test
 	public void createsConsumerOnceWhenInvokedMultipleTimes() {
 		final List<PartitionInfo> partitions = partitions(new Node(0, null, 0));
-		topicsInUse.put(TEST_TOPIC, new TopicInformation("group4-metrics", partitions));
+		topicsInUse.put(TEST_TOPIC, new TopicInformation("group4-metrics", partitions, false));
 
 		metrics.bindTo(meterRegistry);
 
@@ -146,7 +147,7 @@ public class KafkaBinderMetricsTest {
 				.willReturn(consumer);
 
 		final List<PartitionInfo> partitions = partitions(new Node(0, null, 0));
-		topicsInUse.put(TEST_TOPIC, new TopicInformation("group5-metrics", partitions));
+		topicsInUse.put(TEST_TOPIC, new TopicInformation("group5-metrics", partitions, false));
 
 		metrics.bindTo(meterRegistry);
 


### PR DESCRIPTION
If the destination topic is pattern based, only do the basic up/down check
in the health indicator. In this case, the health indicator does not do any
partitions queries as it does for normal topics.

Resolves #430