### PR TITLE
Consumer concurrency settings in Kafka Streams binder

### DIFF
--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/kafka-streams.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/kafka-streams.adoc
@@ -84,7 +84,6 @@ For common configuration options and properties pertaining to binder, refer to t
 === Kafka Streams Properties
 
 The following properties are available at the binder level and must be prefixed with `spring.cloud.stream.kafka.streams.binder.`
-literal.
 
 configuration::
   Map with a key/value pair containing properties pertaining to Apache Kafka Streams API.
@@ -120,7 +119,7 @@ applicationId::
 +
 Default: `none`
 
-The following properties are _only_ available for Kafka Streams producers and must be prefixed with `spring.cloud.stream.kafka.streams.bindings.<binding name>.producer.` literal.
+The following properties are _only_ available for Kafka Streams producers and must be prefixed with `spring.cloud.stream.kafka.streams.bindings.<binding name>.producer.`
 For convenience, if there multiple output bindings and they all require a common value, that can be configured by using the prefix `spring.cloud.stream.kafka.streams.default.producer.`.
 
 keySerde::
@@ -136,8 +135,8 @@ useNativeEncoding::
 +
 Default: `false`.
 
-The following properties are _only_ available for Kafka Streams consumers and must be prefixed with `spring.cloud.stream.kafka.streams.bindings.<binding name>.consumer.`literal.
-For convenience, if there multiple input bindings and they all require a common value, that can be configured by using the prefix `spring.cloud.stream.kafka.streams.default.consumer.`.
+The following properties are available for Kafka Streams consumers and must be prefixed with `spring.cloud.stream.kafka.streams.bindings.<binding-name>.consumer.`
+For convenience, if there are multiple input bindings and they all require a common value, that can be configured by using the prefix `spring.cloud.stream.kafka.streams.default.consumer.`.
 
 applicationId::
  Setting application.id per input binding.
@@ -172,11 +171,6 @@ Default: `earliest`.
 
 Note: Using `resetOffsets` on the consumer does not have any effect on Kafka Streams binder.
 Unlike the message channel based binder, Kafka Streams binder does not seek to beginning or end on demand.
-
-concurrency::
-  Number of stream task threads. Needs at least these many number of partitions in the consuming topic.
-+
-Default: `1`.
 
 === TimeWindow properties:
 

--- a/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/kafka-streams.adoc
+++ b/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/kafka-streams.adoc
@@ -173,6 +173,11 @@ Default: `earliest`.
 Note: Using `resetOffsets` on the consumer does not have any effect on Kafka Streams binder.
 Unlike the message channel based binder, Kafka Streams binder does not seek to beginning or end on demand.
 
+concurrency::
+  Number of stream task threads. Needs at least these many number of partitions in the consuming topic.
++
+Default: `1`.
+
 === TimeWindow properties:
 
 Windowing is an important concept in stream processing applications. Following properties are available to configure

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -443,12 +443,18 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator implements StreamListene
 		Map<String, Object> streamConfigGlobalProperties = applicationContext.getBean("streamConfigGlobalProperties", Map.class);
 
 		KafkaStreamsConsumerProperties extendedConsumerProperties = kafkaStreamsExtendedBindingProperties.getExtendedConsumerProperties(inboundName);
+		streamConfigGlobalProperties.putAll(extendedConsumerProperties.getConfiguration());
 
 		String applicationId = extendedConsumerProperties.getApplicationId();
-
 		//override application.id if set at the individual binding level.
 		if (StringUtils.hasText(applicationId)) {
 			streamConfigGlobalProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+		}
+
+		int concurrency = bindingServiceProperties.getConsumerProperties(inboundName).getConcurrency();
+		// override concurrency if set at the individual binding level.
+		if (concurrency > 1) {
+			streamConfigGlobalProperties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, concurrency);
 		}
 
 		Map<String, KafkaStreamsDlqDispatch> kafkaStreamsDlqDispatchers = applicationContext.getBean("kafkaStreamsDlqDispatchers", Map.class);


### PR DESCRIPTION
* If the consumer concurency settings are provided at the binding level,
  honor that before falling back to the defaults.
* Allow consumer binding specific broker configurations to be set from the application.
* Test changes.

Resolves #474