### PR TITLE
Fixing health indicator issues

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -86,14 +86,21 @@ public class KafkaBinderHealthIndicator implements HealthIndicator {
 					Set<String> downMessages = new HashSet<>();
 					final Map<String, KafkaMessageChannelBinder.TopicInformation> topicsInUse =
 							KafkaBinderHealthIndicator.this.binder.getTopicsInUse();
-					for (String topic : topicsInUse.keySet()) {
-						KafkaMessageChannelBinder.TopicInformation topicInformation = topicsInUse.get(topic);
-						if (!topicInformation.isTopicPattern()) {
-							List<PartitionInfo> partitionInfos = this.metadataConsumer.partitionsFor(topic);
-							for (PartitionInfo partitionInfo : partitionInfos) {
-								if (topicInformation.getPartitionInfos()
-										.contains(partitionInfo) && partitionInfo.leader().id() == -1) {
-									downMessages.add(partitionInfo.toString());
+					if (topicsInUse.isEmpty()) {
+						return Health.down()
+								.withDetail("No topic information available", "Kafka broker is not reachable")
+								.build();
+					}
+					else {
+						for (String topic : topicsInUse.keySet()) {
+							KafkaMessageChannelBinder.TopicInformation topicInformation = topicsInUse.get(topic);
+							if (!topicInformation.isTopicPattern()) {
+								List<PartitionInfo> partitionInfos = this.metadataConsumer.partitionsFor(topic);
+								for (PartitionInfo partitionInfo : partitionInfos) {
+									if (topicInformation.getPartitionInfos()
+											.contains(partitionInfo) && partitionInfo.leader().id() == -1) {
+										downMessages.add(partitionInfo.toString());
+									}
 								}
 							}
 						}

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -738,7 +738,7 @@ public class KafkaMessageChannelBinder extends
 	private Collection<PartitionInfo> getPartitionInfo(String topic,
 			final ExtendedConsumerProperties<KafkaConsumerProperties> extendedConsumerProperties,
 			final ConsumerFactory<?, ?> consumerFactory, int partitionCount) {
-		Collection<PartitionInfo> allPartitions = provisioningProvider.getPartitionsForTopic(partitionCount,
+		return provisioningProvider.getPartitionsForTopic(partitionCount,
 				extendedConsumerProperties.getExtension().isAutoRebalanceEnabled(),
 				() -> {
 					try (Consumer<?, ?> consumer = consumerFactory.createConsumer()) {
@@ -746,7 +746,6 @@ public class KafkaMessageChannelBinder extends
 						return partitionsFor;
 					}
 				});
-		return allPartitions;
 	}
 
 	@Override


### PR DESCRIPTION
During startup if Kafka is down, binder health indicator check
erroneously reports that Kafka is up. Fixing this issue.

Resolves #495