### PR TITLE
Add logging for deserialization failures.

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsMessageConversionDelegate.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsMessageConversionDelegate.java
@@ -140,7 +140,8 @@ public class KafkaStreamsMessageConversionDelegate {
 						LOG.info("Received a tombstone record. This will be skipped from further processing.");
 					}
 				}
-				catch (Exception ignored) {
+				catch (Exception e) {
+					LOG.warn("Deserialization has failed. This will be skipped from further processing.", e);
 					//pass through
 				}
 				return isValidRecord;


### PR DESCRIPTION
The empty catch block makes deserialization issues hard to debug. We had an issue between older producers and the latest version of spring-cloud-stream-kafka-streams (https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/509) and the exception was completely silent.