### PR TITLE
Fix NPE in Kafka Streams binder

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
@@ -78,9 +78,9 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 		for (Map.Entry<String, BinderConfiguration> entry : binderConfigurations.entrySet()) {
 			final BinderConfiguration binderConfiguration = entry.getValue();
 			final String binderType = binderConfiguration.getBinderType();
-			if (binderType.equals(KSTREAM_BINDER_TYPE) ||
+			if (binderType != null && (binderType.equals(KSTREAM_BINDER_TYPE) ||
 					binderType.equals(KTABLE_BINDER_TYPE) ||
-					binderType.equals(GLOBALKTABLE_BINDER_TYPE)) {
+					binderType.equals(GLOBALKTABLE_BINDER_TYPE))) {
 				Map<String, Object> binderProperties = new HashMap<>();
 				this.flatten(null, binderConfiguration.getProperties(), binderProperties);
 				environment.getPropertySources().addFirst(new MapPropertySource("kafkaStreamsBinderEnv", binderProperties));

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateTopicsResult;


### PR DESCRIPTION
Fixing an NPE when type for the binder is not explicitly provided as a configuration.

Resolves #516

Polishing