### PR TITLE
Allow channel specific group names

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -911,11 +911,13 @@ public class KafkaMessageChannelBinder extends
 		props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
 		props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 100);
 		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, anonymous ? "latest" : "earliest");
-		props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
 
 		Map<String, Object> mergedConfig = this.configurationProperties.mergedConsumerConfiguration();
 		if (!ObjectUtils.isEmpty(mergedConfig)) {
 			props.putAll(mergedConfig);
+		}
+		if ((!anonymous && !ObjectUtils.isEmpty(consumerGroup)) || !props.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
+			props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
 		}
 		if (ObjectUtils.isEmpty(props.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG))) {
 			props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.configurationProperties.getKafkaConnectionString());

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -916,7 +916,7 @@ public class KafkaMessageChannelBinder extends
 		if (!ObjectUtils.isEmpty(mergedConfig)) {
 			props.putAll(mergedConfig);
 		}
-		if ((!anonymous && !ObjectUtils.isEmpty(consumerGroup)) || !props.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
+		if ((!anonymous || !props.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) && !ObjectUtils.isEmpty(consumerGroup)) {
 			props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
 		}
 		if (ObjectUtils.isEmpty(props.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG))) {

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateTopicsResult;


### PR DESCRIPTION
- use chanel specific group name over binder level group id/name
config
- use binder level group id/name config if channel group name is
anonymous
- use anonymous group name if binder level group id/name config is
absent
