### PR TITLE
Remove producer partitioned property

### DIFF
--- a/docs/src/main/asciidoc/dlq.adoc
+++ b/docs/src/main/asciidoc/dlq.adoc
@@ -25,10 +25,8 @@ spring.cloud.stream.bindings.input.group=so8400replay
 spring.cloud.stream.bindings.input.destination=error.so8400out.so8400
 
 spring.cloud.stream.bindings.output.destination=so8400out
-spring.cloud.stream.bindings.output.producer.partitioned=true
 
 spring.cloud.stream.bindings.parkingLot.destination=so8400in.parkingLot
-spring.cloud.stream.bindings.parkingLot.producer.partitioned=true
 
 spring.cloud.stream.kafka.binder.configuration.auto.offset.reset=earliest
 

--- a/docs/src/main/asciidoc/partitions.adoc
+++ b/docs/src/main/asciidoc/partitions.adoc
@@ -49,7 +49,6 @@ spring:
         output:
           destination: partitioned.topic
           producer:
-            partitioned: true
             partition-key-expression: headers['partitionKey']
             partition-count: 12
 ----

--- a/docs/src/main/asciidoc/spring-cloud-stream-binder-kafka.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream-binder-kafka.adoc
@@ -10,7 +10,7 @@
 
 [[spring-cloud-stream-binder-kafka-reference]]
 = Spring Cloud Stream Kafka Binder Reference Guide
-Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinathan, Gunnar Hillert, Mark Pollack, Patrick Peralta, Glenn Renfro, Thomas Risberg, Dave Syer, David Turanski, Janne Valkealahti, Benjamin Klein, Henryk Konsek, Gary Russell, Arnaud Jardiné
+Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinathan, Gunnar Hillert, Mark Pollack, Patrick Peralta, Glenn Renfro, Thomas Risberg, Dave Syer, David Turanski, Janne Valkealahti, Benjamin Klein, Henryk Konsek, Gary Russell, Arnaud Jardiné, Soby Chacko
 :doctype: book
 :toc:
 :toclevels: 4


### PR DESCRIPTION
On the producer side, partitioned is a derived property and the applications do not
have to set this explicitly. Remove any explicit references to it from the docs.

Fixes #542