### PR TITLE
Transactional binder producer factory

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -314,7 +314,9 @@ public class KafkaMessageChannelBinder extends
 					List<PartitionInfo> partitionsFor = producer
 							.partitionsFor(destination.getName());
 					producer.close();
-					((DisposableBean) producerFB).destroy();
+					if (this.transactionManager == null) {
+						((DisposableBean) producerFB).destroy();
+					}
 					return partitionsFor;
 				}, destination.getName());
 		this.topicsInUse.put(destination.getName(),


### PR DESCRIPTION
With a transactional binder, the producer factory should not be destroyed.

Resolves #626