### PR TITLE
Kafka Streams multiple function issues

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsApplicationSupportAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsApplicationSupportAutoConfiguration.java
@@ -27,10 +27,12 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Application support configuration for Kafka Streams binder.
  *
+ * @deprecated Features provided on this class can be directly configured in the application itself using Kafka Streams.
  * @author Soby Chacko
  */
 @Configuration
 @EnableConfigurationProperties(KafkaStreamsApplicationSupportProperties.class)
+@Deprecated
 public class KafkaStreamsApplicationSupportAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
@@ -31,12 +31,12 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.stream.binder.BinderConfiguration;
+import org.springframework.cloud.stream.binder.kafka.streams.function.FunctionDetectorCondition;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.serde.CompositeNonNativeSerde;
@@ -48,6 +48,7 @@ import org.springframework.cloud.stream.config.BindingServiceConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
@@ -240,8 +241,7 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 	}
 
 	@Bean
-//	@ConditionalOnProperty("spring.cloud.stream.kafka.streams.function.definition")
-	@ConditionalOnProperty("spring.cloud.stream.function.definition")
+	@Conditional(FunctionDetectorCondition.class)
 	public KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor(BindingServiceProperties bindingServiceProperties,
 																	KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties,
 																	KeyValueSerdeResolver keyValueSerdeResolver,

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/FunctionDetectorCondition.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/FunctionDetectorCondition.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.streams.function;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Custom {@link org.springframework.context.annotation.Condition} that detects the presence
+ * of java.util.Function|Consumer beans. Used for Kafka Streams function support.
+ *
+ * @author Soby Chakco
+ * @since 2.2.0
+ */
+public class FunctionDetectorCondition extends SpringBootCondition {
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		if (context != null &&  context.getBeanFactory() != null) {
+			final Map<String, Function> functionTypes = context.getBeanFactory().getBeansOfType(Function.class);
+			final Map<String, Consumer> consumerTypes = context.getBeanFactory().getBeansOfType(Consumer.class);
+
+			if (!functionTypes.isEmpty() || !consumerTypes.isEmpty()) {
+				return ConditionOutcome.match("Matched. Function/Consumer beans found");
+			}
+			else {
+				return ConditionOutcome.noMatch("No match. No Function/Consumer beans found");
+			}
+		}
+		return ConditionOutcome.noMatch("No match. No Function/Consumer beans found");
+	}
+}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionAutoConfiguration.java
@@ -44,5 +44,4 @@ public class KafkaStreamsFunctionAutoConfiguration {
 	public KafkaStreamsFunctionBeanPostProcessor kafkaStreamsFunctionBeanPostProcessor() {
 		return new KafkaStreamsFunctionBeanPostProcessor();
 	}
-
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionAutoConfiguration.java
@@ -16,34 +16,33 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams.function;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.KafkaStreamsFunctionProcessor;
 import org.springframework.cloud.stream.function.StreamFunctionProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * @author Soby Chacko
+ * @since 2.2.0
  */
 @Configuration
-@ConditionalOnProperty("spring.cloud.stream.function.definition")
 @EnableConfigurationProperties(StreamFunctionProperties.class)
 public class KafkaStreamsFunctionAutoConfiguration {
 
 	@Bean
+	@Conditional(FunctionDetectorCondition.class)
 	public KafkaStreamsFunctionProcessorInvoker kafkaStreamsFunctionProcessorInvoker(
 																					KafkaStreamsFunctionBeanPostProcessor kafkaStreamsFunctionBeanPostProcessor,
-																					KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor,
-																					StreamFunctionProperties properties) {
-		return new KafkaStreamsFunctionProcessorInvoker(kafkaStreamsFunctionBeanPostProcessor.getResolvableType(),
-				properties.getDefinition(), kafkaStreamsFunctionProcessor);
+																					KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor) {
+		return new KafkaStreamsFunctionProcessorInvoker(kafkaStreamsFunctionBeanPostProcessor.getResolvableTypes(),
+				kafkaStreamsFunctionProcessor);
 	}
 
 	@Bean
-	public KafkaStreamsFunctionBeanPostProcessor kafkaStreamsFunctionBeanPostProcessor(
-			StreamFunctionProperties properties) {
-		return new KafkaStreamsFunctionBeanPostProcessor(properties);
+	public KafkaStreamsFunctionBeanPostProcessor kafkaStreamsFunctionBeanPostProcessor() {
+		return new KafkaStreamsFunctionBeanPostProcessor();
 	}
 
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionProcessorInvoker.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionProcessorInvoker.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams.function;
 
+import java.util.Map;
+
 import javax.annotation.PostConstruct;
 
 import org.springframework.cloud.stream.binder.kafka.streams.KafkaStreamsFunctionProcessor;
@@ -29,18 +31,17 @@ import org.springframework.core.ResolvableType;
 class KafkaStreamsFunctionProcessorInvoker {
 
 	private final KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor;
-	private final ResolvableType resolvableType;
-	private final String functionName;
+	private final Map<String, ResolvableType> resolvableTypeMap;
 
-	KafkaStreamsFunctionProcessorInvoker(ResolvableType resolvableType, String functionName,
-												KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor) {
+	KafkaStreamsFunctionProcessorInvoker(Map<String, ResolvableType> resolvableTypeMap,
+										KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor) {
 		this.kafkaStreamsFunctionProcessor = kafkaStreamsFunctionProcessor;
-		this.resolvableType = resolvableType;
-		this.functionName = functionName;
+		this.resolvableTypeMap = resolvableTypeMap;
 	}
 
 	@PostConstruct
 	void invoke() {
-		this.kafkaStreamsFunctionProcessor.orchestrateStreamListenerSetupMethod(resolvableType, functionName);
+		resolvableTypeMap.forEach((key, value) ->
+				this.kafkaStreamsFunctionProcessor.orchestrateFunctionInvoking(value, key));
 	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionWrapperDetector.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionWrapperDetector.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.function.context.WrapperDetector;
 
 /**
  * @author Soby Chacko
+ * @since 2.2.0
  */
 public class KafkaStreamsFunctionWrapperDetector implements WrapperDetector {
 	@Override

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsApplicationSupportProperties.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsApplicationSupportProperties.java
@@ -25,9 +25,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * stream processing and one can provide window specific properties at runtime and use
  * those properties in the applications using this class.
  *
+ * @deprecated The properties exposed by this class can be used directly on Kafka Streams API in the application.
  * @author Soby Chacko
  */
 @ConfigurationProperties("spring.cloud.stream.kafka.streams")
+@Deprecated
 public class KafkaStreamsApplicationSupportProperties {
 
 	private TimeWindow timeWindow;

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountBranchesFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountBranchesFunctionTests.java
@@ -85,7 +85,6 @@ public class KafkaStreamsBinderWordCountBranchesFunctionTests {
 
 		ConfigurableApplicationContext context = app.run("--server.port=0",
 				"--spring.jmx.enabled=false",
-				"--spring.cloud.stream.function.definition=process",
 				"--spring.cloud.stream.bindings.input.destination=words",
 				"--spring.cloud.stream.bindings.output1.destination=counts",
 				"--spring.cloud.stream.bindings.output1.contentType=application/json",

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
@@ -85,7 +85,6 @@ public class KafkaStreamsBinderWordCountFunctionTests {
 
 		try (ConfigurableApplicationContext context = app.run("--server.port=0",
 				"--spring.jmx.enabled=false",
-				"--spring.cloud.stream.function.definition=process",
 				"--spring.cloud.stream.bindings.input.destination=words",
 				"--spring.cloud.stream.bindings.output.destination=counts",
 				"--spring.cloud.stream.bindings.output.contentType=application/json",

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/StreamToGlobalKTableFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/StreamToGlobalKTableFunctionTests.java
@@ -72,7 +72,6 @@ public class StreamToGlobalKTableFunctionTests {
 		app.setWebApplicationType(WebApplicationType.NONE);
 		try (ConfigurableApplicationContext ignored = app.run("--server.port=0",
 				"--spring.jmx.enabled=false",
-				"--spring.cloud.stream.function.definition=process",
 				"--spring.cloud.stream.bindings.input.destination=orders",
 				"--spring.cloud.stream.bindings.input-x.destination=customers",
 				"--spring.cloud.stream.bindings.input-y.destination=products",

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/StreamToTableJoinFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/StreamToTableJoinFunctionTests.java
@@ -231,7 +231,6 @@ public class StreamToTableJoinFunctionTests {
 
 		try (ConfigurableApplicationContext ignored = app.run("--server.port=0",
 				"--spring.jmx.enabled=false",
-				"--spring.cloud.stream.function.definition=process1",
 				"--spring.cloud.stream.bindings.input-1.destination=user-clicks-2",
 				"--spring.cloud.stream.bindings.input-2.destination=user-regions-2",
 				"--spring.cloud.stream.bindings.output.destination=output-topic-2",


### PR DESCRIPTION
Fixing a bug around when we have muliple beans defined as functions/csonumers in the new
Kafka Streams binder functional support.

Polishing

Resolves #636