### PR TITLE
Fix listener naming

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -535,7 +535,7 @@ public class KafkaMessageChannelBinder extends
 			messageListenerContainer
 					.setApplicationEventPublisher(getApplicationContext());
 		}
-		messageListenerContainer.setBeanName(topics + ".container");
+		messageListenerContainer.setBeanName(destination + ".container");
 		// end of these won't be needed...
 		if (!extendedConsumerProperties.getExtension().isAutoCommitOffset()) {
 			messageListenerContainer.getContainerProperties()


### PR DESCRIPTION
Topics used to be a string, now bean name is built using string generated from an array.