### PR TITLE
Infer SerDes used on input/output when possible

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
 
@@ -120,9 +121,15 @@ class KStreamBinder extends
 		this.kafkaTopicProvisioner.provisionProducerDestination(name,
 				extendedProducerProperties);
 		Serde<?> keySerde = this.keyValueSerdeResolver
-				.getOuboundKeySerde(properties.getExtension(), kafkaStreamsBindingInformationCatalogue.getOutboundResolvable());
-		Serde<?> valueSerde = this.keyValueSerdeResolver.getOutboundValueSerde(properties,
-				properties.getExtension(), kafkaStreamsBindingInformationCatalogue.getOutboundResolvable());
+				.getOuboundKeySerde(properties.getExtension(), kafkaStreamsBindingInformationCatalogue.getOutboundKStreamResolvable());
+		Serde<?> valueSerde;
+		if (properties.isUseNativeEncoding()) {
+			valueSerde = this.keyValueSerdeResolver.getOutboundValueSerde(properties,
+					properties.getExtension(), kafkaStreamsBindingInformationCatalogue.getOutboundKStreamResolvable());
+		}
+		else {
+			valueSerde = Serdes.ByteArray();
+		}
 		to(properties.isUseNativeEncoding(), name, outboundBindTarget,
 				(Serde<Object>) keySerde, (Serde<Object>) valueSerde);
 		return new DefaultBinding<>(name, null, outboundBindTarget, null);

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,9 +120,9 @@ class KStreamBinder extends
 		this.kafkaTopicProvisioner.provisionProducerDestination(name,
 				extendedProducerProperties);
 		Serde<?> keySerde = this.keyValueSerdeResolver
-				.getOuboundKeySerde(properties.getExtension());
+				.getOuboundKeySerde(properties.getExtension(), kafkaStreamsBindingInformationCatalogue.getOutboundResolvable());
 		Serde<?> valueSerde = this.keyValueSerdeResolver.getOutboundValueSerde(properties,
-				properties.getExtension());
+				properties.getExtension(), kafkaStreamsBindingInformationCatalogue.getOutboundResolvable());
 		to(properties.isUseNativeEncoding(), name, outboundBindTarget,
 				(Serde<Object>) keySerde, (Serde<Object>) valueSerde);
 		return new DefaultBinding<>(name, null, outboundBindTarget, null);

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -47,7 +47,7 @@ class KafkaStreamsBindingInformationCatalogue {
 
 	private final Set<StreamsBuilderFactoryBean> streamsBuilderFactoryBeans = new HashSet<>();
 
-	private ResolvableType outboundResolvable;
+	private ResolvableType outboundKStreamResolvable;
 
 	/**
 	 * For a given bounded {@link KStream}, retrieve it's corresponding destination on the
@@ -125,11 +125,11 @@ class KafkaStreamsBindingInformationCatalogue {
 		return this.streamsBuilderFactoryBeans;
 	}
 
-	public void addOutputKStreamResolvable(ResolvableType outboundResolvable) {
-		this.outboundResolvable = outboundResolvable;
+	public void setOutboundKStreamResolvable(ResolvableType outboundResolvable) {
+		this.outboundKStreamResolvable = outboundResolvable;
 	}
 
-	public ResolvableType getOutboundResolvable() {
-		return outboundResolvable;
+	public ResolvableType getOutboundKStreamResolvable() {
+		return outboundKStreamResolvable;
 	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsConsumerProperties;
 import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.core.ResolvableType;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 
 /**
@@ -45,6 +46,9 @@ class KafkaStreamsBindingInformationCatalogue {
 	private final Map<KStream<?, ?>, KafkaStreamsConsumerProperties> consumerProperties = new ConcurrentHashMap<>();
 
 	private final Set<StreamsBuilderFactoryBean> streamsBuilderFactoryBeans = new HashSet<>();
+
+	private Map<KStream, ResolvableType> outputBindings;
+	private ResolvableType outboundResolvable;
 
 	/**
 	 * For a given bounded {@link KStream}, retrieve it's corresponding destination on the
@@ -122,4 +126,19 @@ class KafkaStreamsBindingInformationCatalogue {
 		return this.streamsBuilderFactoryBeans;
 	}
 
+	public void addThisMap(Map<KStream, ResolvableType> outputBindings) {
+		this.outputBindings = outputBindings;
+	}
+
+	public Map<KStream, ResolvableType> getOutputBindings() {
+		return outputBindings;
+	}
+
+	public void addOutputKStreamResolvable(ResolvableType outboundResolvable) {
+		this.outboundResolvable = outboundResolvable;
+	}
+
+	public ResolvableType getOutboundResolvable() {
+		return outboundResolvable;
+	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -47,7 +47,6 @@ class KafkaStreamsBindingInformationCatalogue {
 
 	private final Set<StreamsBuilderFactoryBean> streamsBuilderFactoryBeans = new HashSet<>();
 
-	private Map<KStream, ResolvableType> outputBindings;
 	private ResolvableType outboundResolvable;
 
 	/**
@@ -124,14 +123,6 @@ class KafkaStreamsBindingInformationCatalogue {
 
 	Set<StreamsBuilderFactoryBean> getStreamsBuilderFactoryBeans() {
 		return this.streamsBuilderFactoryBeans;
-	}
-
-	public void addThisMap(Map<KStream, ResolvableType> outputBindings) {
-		this.outputBindings = outputBindings;
-	}
-
-	public Map<KStream, ResolvableType> getOutputBindings() {
-		return outputBindings;
 	}
 
 	public void addOutputKStreamResolvable(ResolvableType outboundResolvable) {

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsFunctionProcessor.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsFunctionProcessor.java
@@ -189,7 +189,7 @@ public class KafkaStreamsFunctionProcessor implements ApplicationContextAware {
 					i++;
 				}
 				if (result != null) {
-					kafkaStreamsBindingInformationCatalogue.addOutputKStreamResolvable(
+					kafkaStreamsBindingInformationCatalogue.setOutboundKStreamResolvable(
 							outboundResolvableType != null ? outboundResolvableType : resolvableType.getGeneric(1));
 					final Set<String> outputs = new TreeSet<>(origOutputs);
 					final Iterator<String> iterator = outputs.iterator();
@@ -259,16 +259,14 @@ public class KafkaStreamsFunctionProcessor implements ApplicationContextAware {
 							this.kafkaStreamsExtendedBindingProperties.getExtendedConsumerProperties(input);
 					//get state store spec
 
-					Serde<?> keySerde;
+					Serde<?> keySerde = this.keyValueSerdeResolver.getInboundKeySerde(extendedConsumerProperties, stringResolvableTypeMap.get(input));
 					Serde<?> valueSerde;
 
 					if (bindingServiceProperties.getConsumerProperties(input).isUseNativeDecoding()) {
-						keySerde = this.keyValueSerdeResolver.getInboundKeySerde(extendedConsumerProperties, stringResolvableTypeMap.get(input));
 						valueSerde = this.keyValueSerdeResolver.getInboundValueSerde(
 								bindingProperties.getConsumer(), extendedConsumerProperties, stringResolvableTypeMap.get(input));
 					}
 					else {
-						keySerde = Serdes.ByteArray();
 						valueSerde = Serdes.ByteArray();
 					}
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsFunctionProcessor.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsFunctionProcessor.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -94,6 +95,8 @@ public class KafkaStreamsFunctionProcessor implements ApplicationContextAware {
 	private Set<String> origInputs = new TreeSet<>();
 	private Set<String> origOutputs = new TreeSet<>();
 
+	private ResolvableType outboundResolvableType;
+
 	public KafkaStreamsFunctionProcessor(BindingServiceProperties bindingServiceProperties,
 										KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties,
 										KeyValueSerdeResolver keyValueSerdeResolver,
@@ -132,18 +135,20 @@ public class KafkaStreamsFunctionProcessor implements ApplicationContextAware {
 		resolvableTypeMap.put(next, resolvableType.getGeneric(0));
 		origInputs.remove(next);
 
+		ResolvableType iterableResType = resolvableType;
 		for (int i = 1; i < inputCount; i++) {
 			if (iterator.hasNext()) {
-				ResolvableType generic = resolvableType.getGeneric(1);
-				if (generic.getRawClass() != null &&
-						(generic.getRawClass().equals(Function.class) ||
-								generic.getRawClass().equals(Consumer.class))) {
+				iterableResType = iterableResType.getGeneric(1);
+				if (iterableResType.getRawClass() != null &&
+						(iterableResType.getRawClass().equals(Function.class) ||
+								iterableResType.getRawClass().equals(Consumer.class))) {
 					final String next1 = iterator.next();
-					resolvableTypeMap.put(next1, generic.getGeneric(0));
+					resolvableTypeMap.put(next1, iterableResType.getGeneric(0));
 					origInputs.remove(next1);
 				}
 			}
 		}
+		outboundResolvableType = iterableResType.getGeneric(1);
 		return resolvableTypeMap;
 	}
 
@@ -184,6 +189,8 @@ public class KafkaStreamsFunctionProcessor implements ApplicationContextAware {
 					i++;
 				}
 				if (result != null) {
+					kafkaStreamsBindingInformationCatalogue.addOutputKStreamResolvable(
+							outboundResolvableType != null ? outboundResolvableType : resolvableType.getGeneric(1));
 					final Set<String> outputs = new TreeSet<>(origOutputs);
 					final Iterator<String> iterator = outputs.iterator();
 
@@ -251,9 +258,19 @@ public class KafkaStreamsFunctionProcessor implements ApplicationContextAware {
 					KafkaStreamsConsumerProperties extendedConsumerProperties =
 							this.kafkaStreamsExtendedBindingProperties.getExtendedConsumerProperties(input);
 					//get state store spec
-					Serde<?> keySerde = this.keyValueSerdeResolver.getInboundKeySerde(extendedConsumerProperties);
-					Serde<?> valueSerde = this.keyValueSerdeResolver.getInboundValueSerde(
-							bindingProperties.getConsumer(), extendedConsumerProperties);
+
+					Serde<?> keySerde;
+					Serde<?> valueSerde;
+
+					if (bindingServiceProperties.getConsumerProperties(input).isUseNativeDecoding()) {
+						keySerde = this.keyValueSerdeResolver.getInboundKeySerde(extendedConsumerProperties, stringResolvableTypeMap.get(input));
+						valueSerde = this.keyValueSerdeResolver.getInboundValueSerde(
+								bindingProperties.getConsumer(), extendedConsumerProperties, stringResolvableTypeMap.get(input));
+					}
+					else {
+						keySerde = Serdes.ByteArray();
+						valueSerde = Serdes.ByteArray();
+					}
 
 					final KafkaConsumerProperties.StartOffset startOffset = extendedConsumerProperties.getStartOffset();
 					Topology.AutoOffsetReset autoOffsetReset = null;

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -64,6 +65,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.kafka.config.KafkaStreamsConfiguration;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
@@ -190,6 +192,7 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator
 					Assert.isTrue(methodAnnotatedOutboundNames.length == 1,
 							"Result does not match with the number of declared outbounds");
 				}
+				kafkaStreamsBindingInformationCatalogue.addOutputKStreamResolvable(ResolvableType.forMethodReturnType(method));
 				if (result.getClass().isArray()) {
 					Object[] outboundKStreams = (Object[]) result;
 					int i = 0;
@@ -268,10 +271,21 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator
 							.getExtendedConsumerProperties(inboundName);
 					// get state store spec
 					KafkaStreamsStateStoreProperties spec = buildStateStoreSpec(method);
-					Serde<?> keySerde = this.keyValueSerdeResolver
-							.getInboundKeySerde(extendedConsumerProperties);
-					Serde<?> valueSerde = this.keyValueSerdeResolver.getInboundValueSerde(
-							bindingProperties.getConsumer(), extendedConsumerProperties);
+
+					Serde<?> keySerde;
+					Serde<?> valueSerde;
+
+					if (bindingServiceProperties.getConsumerProperties(inboundName).isUseNativeDecoding()) {
+
+						keySerde = this.keyValueSerdeResolver
+								.getInboundKeySerde(extendedConsumerProperties, ResolvableType.forMethodParameter(methodParameter));
+						valueSerde = this.keyValueSerdeResolver.getInboundValueSerde(
+								bindingProperties.getConsumer(), extendedConsumerProperties, ResolvableType.forMethodParameter(methodParameter));
+					}
+					else {
+						keySerde = Serdes.ByteArray();
+						valueSerde = Serdes.ByteArray();
+					}
 
 					final KafkaConsumerProperties.StartOffset startOffset = extendedConsumerProperties
 							.getStartOffset();

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -192,7 +192,7 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator
 					Assert.isTrue(methodAnnotatedOutboundNames.length == 1,
 							"Result does not match with the number of declared outbounds");
 				}
-				kafkaStreamsBindingInformationCatalogue.addOutputKStreamResolvable(ResolvableType.forMethodReturnType(method));
+				kafkaStreamsBindingInformationCatalogue.setOutboundKStreamResolvable(ResolvableType.forMethodReturnType(method));
 				if (result.getClass().isArray()) {
 					Object[] outboundKStreams = (Object[]) result;
 					int i = 0;
@@ -272,18 +272,16 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator
 					// get state store spec
 					KafkaStreamsStateStoreProperties spec = buildStateStoreSpec(method);
 
-					Serde<?> keySerde;
+					Serde<?> keySerde = this.keyValueSerdeResolver
+							.getInboundKeySerde(extendedConsumerProperties, ResolvableType.forMethodParameter(methodParameter));
 					Serde<?> valueSerde;
 
 					if (bindingServiceProperties.getConsumerProperties(inboundName).isUseNativeDecoding()) {
-
-						keySerde = this.keyValueSerdeResolver
-								.getInboundKeySerde(extendedConsumerProperties, ResolvableType.forMethodParameter(methodParameter));
 						valueSerde = this.keyValueSerdeResolver.getInboundValueSerde(
 								bindingProperties.getConsumer(), extendedConsumerProperties, ResolvableType.forMethodParameter(methodParameter));
 					}
 					else {
-						keySerde = Serdes.ByteArray();
+						//keySerde = Serdes.ByteArray();
 						valueSerde = Serdes.ByteArray();
 					}
 

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountBranchesFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountBranchesFunctionTests.java
@@ -94,9 +94,9 @@ public class KafkaStreamsBinderWordCountBranchesFunctionTests {
 						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde" +
 						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output1.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output3.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output1.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output3.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
 				"--spring.cloud.stream.kafka.streams.timeWindow.length=5000",
 				"--spring.cloud.stream.kafka.streams.timeWindow.advanceBy=0",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId" +

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
@@ -93,7 +93,7 @@ public class KafkaStreamsBinderWordCountFunctionTests {
 						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde" +
 						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+				//"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
 				"--spring.cloud.stream.kafka.streams.binder.brokers=" + embeddedKafka.getBrokersAsString())) {
 			receiveAndValidate(context);
 		}

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/StreamToTableJoinFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/StreamToTableJoinFunctionTests.java
@@ -88,18 +88,6 @@ public class StreamToTableJoinFunctionTests {
 				"--spring.cloud.stream.bindings.input-1.destination=user-clicks-1",
 				"--spring.cloud.stream.bindings.input-2.destination=user-regions-1",
 				"--spring.cloud.stream.bindings.output.destination=output-topic-1",
-				"--spring.cloud.stream.kafka.streams.bindings.input-1.consumer.keySerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-1.consumer.valueSerde" +
-						"=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-2.consumer.keySerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-2.consumer.valueSerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde" +
-						"=org.apache.kafka.common.serialization.Serdes$LongSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde" +
 						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde" +
@@ -236,18 +224,6 @@ public class StreamToTableJoinFunctionTests {
 				"--spring.cloud.stream.bindings.output.producer.useNativeEncoding=true",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.auto.offset.reset=latest",
 				"--spring.cloud.stream.kafka.streams.bindings.input-1.consumer.startOffset=earliest",
-				"--spring.cloud.stream.kafka.streams.bindings.input-1.consumer.keySerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-1.consumer.valueSerde" +
-						"=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-2.consumer.keySerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-2.consumer.valueSerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde" +
-						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde" +
-						"=org.apache.kafka.common.serialization.Serdes$LongSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde" +
 						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde" +

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/DeserializationErrorHandlerByKafkaTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/DeserializationErrorHandlerByKafkaTests.java
@@ -109,7 +109,7 @@ public abstract class DeserializationErrorHandlerByKafkaTests {
 			"spring.cloud.stream.kafka.streams.bindings.input.consumer.application-id=deser-kafka-dlq",
 			"spring.cloud.stream.bindings.input.group=group",
 			"spring.cloud.stream.kafka.streams.binder.serdeError=sendToDlq",
-			"spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde="
+			"spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde="
 					+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde" }, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 	// @checkstyle:on
 	public static class DeserializationByKafkaAndDlqTests
@@ -148,10 +148,11 @@ public abstract class DeserializationErrorHandlerByKafkaTests {
 	// @checkstyle:off
 	@SpringBootTest(properties = {
 			"spring.cloud.stream.bindings.input.destination=word1,word2",
-			"spring.cloud.stream.kafka.streams.default.consumer.applicationId=deser-kafka-dlq-multi-input",
+			"spring.cloud.stream.kafka.streams.bindings.input.consumer.application-id=deser-kafka-dlq-multi-input",
+			//"spring.cloud.stream.kafka.streams.default.consumer.applicationId=deser-kafka-dlq-multi-input",
 			"spring.cloud.stream.bindings.input.group=groupx",
 			"spring.cloud.stream.kafka.streams.binder.serdeError=sendToDlq",
-			"spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde="
+			"spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde="
 					+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde" }, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 	// @checkstyle:on
 	public static class DeserializationByKafkaAndDlqTestsWithMultipleInputs

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/DeserializtionErrorHandlerByBinderTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/DeserializtionErrorHandlerByBinderTests.java
@@ -111,8 +111,8 @@ public abstract class DeserializtionErrorHandlerByBinderTests {
 					+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 			"spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 					+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-			"spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
-					+ "=org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+//			"spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
+//					+ "=org.apache.kafka.common.serialization.Serdes$IntegerSerde",
 			"spring.cloud.stream.kafka.streams.binder.serdeError=sendToDlq",
 			"spring.cloud.stream.kafka.streams.bindings.input.consumer.application-id"
 					+ "=deserializationByBinderAndDlqTests",
@@ -160,8 +160,8 @@ public abstract class DeserializtionErrorHandlerByBinderTests {
 					+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 			"spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 					+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-			"spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
-					+ "=org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+//			"spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
+//					+ "=org.apache.kafka.common.serialization.Serdes$IntegerSerde",
 			"spring.cloud.stream.kafka.streams.binder.serdeError=sendToDlq",
 			"spring.cloud.stream.kafka.streams.bindings.input.consumer.application-id"
 					+ "=deserializationByBinderAndDlqTestsWithMultipleInputs",

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderHealthIndicatorTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderHealthIndicatorTests.java
@@ -207,14 +207,14 @@ public class KafkaStreamsBinderHealthIndicatorTests {
 						+ "org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde="
 						+ "org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde="
-						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde="
+//						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId="
 						+ "ApplicationHealthTest-xyz",
 				"--spring.cloud.stream.kafka.streams.binder.brokers="
@@ -237,23 +237,23 @@ public class KafkaStreamsBinderHealthIndicatorTests {
 						+ "org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde="
 						+ "org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde="
-						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.keySerde="
-						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
-
-				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
-				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde="
+//						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.keySerde="
+//						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
+//
+//				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderHealthIndicatorTests.Product",
 
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId="
 						+ "ApplicationHealthTest-xyz",

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderMultipleInputTopicsTest.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderMultipleInputTopicsTest.java
@@ -108,7 +108,7 @@ public class KafkaStreamsBinderMultipleInputTopicsTest {
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
 				"--spring.cloud.stream.kafka.streams.timeWindow.length=5000",
 				"--spring.cloud.stream.kafka.streams.timeWindow.advanceBy=0",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId"

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderPojoInputAndPrimitiveTypeOutputTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderPojoInputAndPrimitiveTypeOutputTests.java
@@ -97,13 +97,13 @@ public class KafkaStreamsBinderPojoInputAndPrimitiveTypeOutputTests {
 						+ "org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde="
 						+ "org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde="
-						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde="
-						+ "org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderPojoInputAndPrimitiveTypeOutputTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde="
+//						+ "org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde="
+//						+ "org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsBinderPojoInputAndPrimitiveTypeOutputTests.Product",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId="
 						+ "KafkaStreamsBinderPojoInputAndPrimitiveTypeOutputTests-xyz",
 				"--spring.cloud.stream.kafka.streams.binder.brokers="

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderWordCountIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderWordCountIntegrationTests.java
@@ -114,7 +114,7 @@ public class KafkaStreamsBinderWordCountIntegrationTests {
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+				//"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
 				"--spring.cloud.stream.kafka.streams.timeWindow.length=5000",
 				"--spring.cloud.stream.kafka.streams.timeWindow.advanceBy=0",
 				"--spring.cloud.stream.kafka.streams.binder.brokers="

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsInteractiveQueryIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsInteractiveQueryIntegrationTests.java
@@ -100,9 +100,9 @@ public class KafkaStreamsInteractiveQueryIntegrationTests {
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsInteractiveQueryIntegrationTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsInteractiveQueryIntegrationTests.Product",
 
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId=ProductCountApplication-abc",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.application.server"

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsStateStoreIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsStateStoreIntegrationTests.java
@@ -67,9 +67,9 @@ public class KafkaStreamsStateStoreIntegrationTests {
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsStateStoreIntegrationTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsStateStoreIntegrationTests.Product",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId"
 						+ "=KafkaStreamsStateStoreIntegrationTests-abc",
 				"--spring.cloud.stream.kafka.streams.binder.brokers="
@@ -100,12 +100,12 @@ public class KafkaStreamsStateStoreIntegrationTests {
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input1.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input1.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsStateStoreIntegrationTests.Product",
-				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsStateStoreIntegrationTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.input1.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input1.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsStateStoreIntegrationTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input2.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkaStreamsStateStoreIntegrationTests.Product",
 				"--spring.cloud.stream.kafka.streams.bindings.input1.consumer.applicationId"
 						+ "=KafkaStreamsStateStoreIntegrationTests-abc",
 				"--spring.cloud.stream.kafka.streams.binder.brokers="

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkastreamsBinderPojoInputStringOutputIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkastreamsBinderPojoInputStringOutputIntegrationTests.java
@@ -97,11 +97,11 @@ public class KafkastreamsBinderPojoInputStringOutputIntegrationTests {
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$IntegerSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
-						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkastreamsBinderPojoInputStringOutputIntegrationTests.Product",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$IntegerSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.configuration.spring.json.value.default.type=" +
+//						"org.springframework.cloud.stream.binder.kafka.streams.integration.KafkastreamsBinderPojoInputStringOutputIntegrationTests.Product",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId=ProductCountApplication-xyz",
 				"--spring.cloud.stream.kafka.streams.binder.brokers="
 						+ embeddedKafka.getBrokersAsString(),

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/StreamToGlobalKTableJoinIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/StreamToGlobalKTableJoinIntegrationTests.java
@@ -48,7 +48,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
-import org.springframework.kafka.support.serializer.JsonSerde;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
@@ -81,26 +81,26 @@ public class StreamToGlobalKTableJoinIntegrationTests {
 				"--spring.cloud.stream.bindings.input-x.destination=customers",
 				"--spring.cloud.stream.bindings.input-y.destination=products",
 				"--spring.cloud.stream.bindings.output.destination=enriched-order",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde"
-						+ "=org.springframework.cloud.stream.binder.kafka.streams.integration"
-						+ ".StreamToGlobalKTableJoinIntegrationTests$OrderSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-x.consumer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-x.consumer.valueSerde"
-						+ "=org.springframework.cloud.stream.binder.kafka.streams.integration."
-						+ "StreamToGlobalKTableJoinIntegrationTests$CustomerSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-y.consumer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input-y.consumer.valueSerde"
-						+ "=org.springframework.cloud.stream.binder.kafka.streams."
-						+ "integration.StreamToGlobalKTableJoinIntegrationTests$ProductSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde"
-						+ "=org.springframework.cloud.stream.binder.kafka.streams.integration"
-						+ ".StreamToGlobalKTableJoinIntegrationTests$EnrichedOrderSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde"
+//						+ "=org.springframework.cloud.stream.binder.kafka.streams.integration"
+//						+ ".StreamToGlobalKTableJoinIntegrationTests$OrderSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input-x.consumer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input-x.consumer.valueSerde"
+//						+ "=org.springframework.cloud.stream.binder.kafka.streams.integration."
+//						+ "StreamToGlobalKTableJoinIntegrationTests$CustomerSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input-y.consumer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input-y.consumer.valueSerde"
+//						+ "=org.springframework.cloud.stream.binder.kafka.streams."
+//						+ "integration.StreamToGlobalKTableJoinIntegrationTests$ProductSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde"
+//						+ "=org.springframework.cloud.stream.binder.kafka.streams.integration"
+//						+ ".StreamToGlobalKTableJoinIntegrationTests$EnrichedOrderSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
@@ -116,9 +116,8 @@ public class StreamToGlobalKTableJoinIntegrationTests {
 					.producerProps(embeddedKafka);
 			senderPropsCustomer.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
 					LongSerializer.class);
-			CustomerSerde customerSerde = new CustomerSerde();
 			senderPropsCustomer.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-					customerSerde.serializer().getClass());
+					JsonSerializer.class);
 
 			DefaultKafkaProducerFactory<Long, Customer> pfCustomer = new DefaultKafkaProducerFactory<>(
 					senderPropsCustomer);
@@ -135,9 +134,8 @@ public class StreamToGlobalKTableJoinIntegrationTests {
 					.producerProps(embeddedKafka);
 			senderPropsProduct.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
 					LongSerializer.class);
-			ProductSerde productSerde = new ProductSerde();
 			senderPropsProduct.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-					productSerde.serializer().getClass());
+					JsonSerializer.class);
 
 			DefaultKafkaProducerFactory<Long, Product> pfProduct = new DefaultKafkaProducerFactory<>(
 					senderPropsProduct);
@@ -155,9 +153,8 @@ public class StreamToGlobalKTableJoinIntegrationTests {
 					.producerProps(embeddedKafka);
 			senderPropsOrder.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
 					LongSerializer.class);
-			OrderSerde orderSerde = new OrderSerde();
 			senderPropsOrder.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-					orderSerde.serializer().getClass());
+					JsonSerializer.class);
 
 			DefaultKafkaProducerFactory<Long, Order> pfOrder = new DefaultKafkaProducerFactory<>(
 					senderPropsOrder);
@@ -176,9 +173,8 @@ public class StreamToGlobalKTableJoinIntegrationTests {
 			consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 			consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
 					LongDeserializer.class);
-			EnrichedOrderSerde enrichedOrderSerde = new EnrichedOrderSerde();
 			consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-					enrichedOrderSerde.deserializer().getClass());
+					JsonDeserializer.class);
 			consumerProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE,
 					"org.springframework.cloud.stream.binder.kafka.streams.integration."
 							+ "StreamToGlobalKTableJoinIntegrationTests.EnrichedOrder");
@@ -368,20 +364,20 @@ public class StreamToGlobalKTableJoinIntegrationTests {
 
 	}
 
-	public static class OrderSerde extends JsonSerde<Order> {
-
-	}
-
-	public static class CustomerSerde extends JsonSerde<Customer> {
-
-	}
-
-	public static class ProductSerde extends JsonSerde<Product> {
-
-	}
-
-	public static class EnrichedOrderSerde extends JsonSerde<EnrichedOrder> {
-
-	}
+//	public static class OrderSerde extends JsonSerde<Order> {
+//
+//	}
+//
+//	public static class CustomerSerde extends JsonSerde<Customer> {
+//
+//	}
+//
+//	public static class ProductSerde extends JsonSerde<Product> {
+//
+//	}
+//
+//	public static class EnrichedOrderSerde extends JsonSerde<EnrichedOrder> {
+//
+//	}
 
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/StreamToTableJoinIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/StreamToTableJoinIntegrationTests.java
@@ -96,18 +96,18 @@ public class StreamToTableJoinIntegrationTests {
 				"--spring.cloud.stream.bindings.input-x.destination=user-regions-1",
 				"--spring.cloud.stream.bindings.output.destination=output-topic-1",
 
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.valueSerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.valueSerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
@@ -247,18 +247,18 @@ public class StreamToTableJoinIntegrationTests {
 
 				"--spring.cloud.stream.kafka.streams.binder.configuration.auto.offset.reset=latest",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.startOffset=earliest",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.valueSerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde"
-						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.valueSerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.inputX.consumer.valueSerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.keySerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output.producer.valueSerde"
+//						+ "=org.apache.kafka.common.serialization.Serdes$LongSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/WordCountMultipleBranchesIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/WordCountMultipleBranchesIntegrationTests.java
@@ -103,9 +103,9 @@ public class WordCountMultipleBranchesIntegrationTests {
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
 				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde"
 						+ "=org.apache.kafka.common.serialization.Serdes$StringSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output1.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
-				"--spring.cloud.stream.kafka.streams.bindings.output3.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output1.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output2.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
+//				"--spring.cloud.stream.kafka.streams.bindings.output3.producer.valueSerde=org.springframework.kafka.support.serializer.JsonSerde",
 				"--spring.cloud.stream.kafka.streams.timeWindow.length=5000",
 				"--spring.cloud.stream.kafka.streams.timeWindow.advanceBy=0",
 				"--spring.cloud.stream.kafka.streams.bindings.input.consumer.applicationId"


### PR DESCRIPTION
When using native de/serializaion (which is now the default), the binder should infer the common Serde's
used on input and output. The Serdes inferred are - Integer, Long, Short, Double, Float, String, byte[] and
Spring Kafka provided JsonSerde.

Resolves #368