### PR TITLE
GH-423 Add option to use KafkaHeaders.TOPIC Header

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -327,7 +327,11 @@ The replication factor to use when provisioning topics. Overrides the binder-wid
 Ignored if `replicas-assignments` is present.
 +
 Default: none (the binder-wide default of 1 is used).
-
+useTopicHeader::
+Set to `true` to override the default binding destination (topic name) with the value of the `KafkaHeaders.TOPIC` message header in the outbound message.
+If the header is not present, the default binding destination is used.
+Default: `false`.
++
 
 NOTE: The Kafka binder uses the `partitionCount` setting of the producer as a hint to create a topic with the given partition count (in conjunction with the `minPartitionCount`, the maximum of the two being the value being used).
 Exercise caution when configuring both `minPartitionCount` for a binder and `partitionCount` for an application, as the larger value is used.

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaProducerProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaProducerProperties.java
@@ -50,6 +50,8 @@ public class KafkaProducerProperties {
 
 	private KafkaTopicProperties topic = new KafkaTopicProperties();
 
+	private boolean useTopicHeader;
+
 	public int getBufferSize() {
 		return this.bufferSize;
 	}
@@ -136,6 +138,14 @@ public class KafkaProducerProperties {
 
 	public void setTopic(KafkaTopicProperties topic) {
 		this.topic = topic;
+	}
+
+	public boolean isUseTopicHeader() {
+		return this.useTopicHeader;
+	}
+
+	public void setUseTopicHeader(boolean useTopicHeader) {
+		this.useTopicHeader = useTopicHeader;
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/423

Add an option to override the default binding destination with the value
of the header, if present.