### PR TITLE
Updates for latest S-K snapshot

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -733,12 +733,17 @@ public class KafkaMessageChannelBinder extends
 	}
 
 	private Object checkReset(boolean resetOffsets, final Object resetTo) {
-		if (resetOffsets && !"earliest".equals(resetTo) && !"latest".equals(resetTo)) {
+		if (!resetOffsets) {
+			return null;
+		}
+		else if (!"earliest".equals(resetTo) && !"latest".equals(resetTo)) {
 			logger.warn("no (or unknown) " + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG
 					+ " property cannot reset");
 			return null;
 		}
-		return resetTo;
+		else {
+			return resetTo;
+		}
 	}
 
 	@Override

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -114,7 +114,7 @@ import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.SendResult;
-import org.springframework.kafka.support.TopicPartitionInitialOffset;
+import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.kafka.test.core.BrokerAddress;
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
@@ -2455,14 +2455,15 @@ public class KafkaBinderTests extends
 			binding = binder.bindConsumer(testTopicName, "test-x", input,
 					consumerProperties);
 
-			TopicPartitionInitialOffset[] listenedPartitions = TestUtils.getPropertyValue(
+			ContainerProperties containerProps = TestUtils.getPropertyValue(
 					binding,
-					"lifecycle.messageListenerContainer.containerProperties.topicPartitions",
-					TopicPartitionInitialOffset[].class);
+					"lifecycle.messageListenerContainer.containerProperties",
+					ContainerProperties.class);
+			TopicPartitionOffset[] listenedPartitions = containerProps.getTopicPartitionsToAssign();
 			assertThat(listenedPartitions).hasSize(2);
 			assertThat(listenedPartitions).contains(
-					new TopicPartitionInitialOffset(testTopicName, 2),
-					new TopicPartitionInitialOffset(testTopicName, 5));
+					new TopicPartitionOffset(testTopicName, 2),
+					new TopicPartitionOffset(testTopicName, 5));
 			int partitions = invokePartitionSize(testTopicName);
 			assertThat(partitions).isEqualTo(6);
 		}


### PR DESCRIPTION
- change `TopicPartitionInitialOffset` to `TopicPartitionOffset`
- when resetting with manual assignment, set the SeekPosition earlier rather than
  relying on direct updat of the `ContainerProperties` field
- set `missingTopicsFatal` to `false` in mock test to avoid log messages about missing bootstrap servers