### PR TITLE
Joining two input KStreams

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
 
+import org.springframework.aop.framework.Advised;
 import org.springframework.cloud.stream.binder.AbstractBinder;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
 import org.springframework.cloud.stream.binder.Binding;
@@ -96,8 +97,14 @@ class KStreamBinder extends
 			// @checkstyle:off
 			ExtendedConsumerProperties<KafkaStreamsConsumerProperties> properties) {
 		// @checkstyle:on
-		this.kafkaStreamsBindingInformationCatalogue
-				.registerConsumerProperties(inputTarget, properties.getExtension());
+//		this.kafkaStreamsBindingInformationCatalogue
+//				.registerConsumerProperties(inputTarget, properties.getExtension());
+
+		KStream<Object, Object> delegate = ((KStreamBoundElementFactory.KStreamWrapperHandler)
+				((Advised) inputTarget).getAdvisors()[0].getAdvice()).getDelegate();
+
+		this.kafkaStreamsBindingInformationCatalogue.registerConsumerProperties(delegate, properties.getExtension());
+
 		if (!StringUtils.hasText(group)) {
 			group = this.binderConfigurationProperties.getApplicationId();
 		}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBoundElementFactory.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBoundElementFactory.java
@@ -102,7 +102,7 @@ class KStreamBoundElementFactory extends AbstractBindingTargetFactory<KStream> {
 
 	}
 
-	private static class KStreamWrapperHandler
+	static class KStreamWrapperHandler
 			implements KStreamWrapper, MethodInterceptor {
 
 		private KStream<Object, Object> delegate;
@@ -133,6 +133,9 @@ class KStreamBoundElementFactory extends AbstractBindingTargetFactory<KStream> {
 			}
 		}
 
+		public KStream<Object, Object> getDelegate() {
+			return delegate;
+		}
 	}
 
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -152,4 +152,13 @@ class KafkaStreamsBindingInformationCatalogue {
 	Serde<?> getKeySerde(KStream<?, ?> kStreamTarget) {
 		return this.keySerdeInfo.get(kStreamTarget);
 	}
+
+
+	public Map<KStream<?, ?>, BindingProperties> getBindingProperties() {
+		return bindingProperties;
+	}
+
+	public Map<KStream<?, ?>, KafkaStreamsConsumerProperties> getConsumerProperties() {
+		return consumerProperties;
+	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -273,14 +273,17 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator extends AbstractKafkaStr
 						// wrap the proxy created during the initial target type binding
 						// with real object (KStream)
 						kStreamWrapper.wrap((KStream<Object, Object>) stream);
-						this.kafkaStreamsBindingInformationCatalogue.addKeySerde((KStream) kStreamWrapper, keySerde);
+						this.kafkaStreamsBindingInformationCatalogue.addKeySerde(stream, keySerde);
+						BindingProperties bindingProperties1 = this.kafkaStreamsBindingInformationCatalogue.getBindingProperties().get(kStreamWrapper);
+						this.kafkaStreamsBindingInformationCatalogue.registerBindingProperties(stream, bindingProperties1);
+
 						this.kafkaStreamsBindingInformationCatalogue
 								.addStreamBuilderFactory(streamsBuilderFactoryBean);
 						for (StreamListenerParameterAdapter streamListenerParameterAdapter : adapters) {
 							if (streamListenerParameterAdapter.supports(stream.getClass(),
 									methodParameter)) {
 								arguments[parameterIndex] = streamListenerParameterAdapter
-										.adapt(kStreamWrapper, methodParameter);
+										.adapt(stream, methodParameter);
 								break;
 							}
 						}


### PR DESCRIPTION
When joining two input KStreams, the binder throws an exceptin.
Fixing this issue by passing the wrapped target KStream from the
proxy object to the adapted StreamListener method.

Resolves #701