### PR TITLE
Function detector condition Kafka Streams

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
@@ -266,21 +266,6 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 	}
 
 	@Bean
-	@Conditional(FunctionDetectorCondition.class)
-	public KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor(BindingServiceProperties bindingServiceProperties,
-																	KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties,
-																	KeyValueSerdeResolver keyValueSerdeResolver,
-																	KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue,
-																	KafkaStreamsMessageConversionDelegate kafkaStreamsMessageConversionDelegate,
-																	ObjectProvider<CleanupConfig> cleanupConfig,
-																	KafkaStreamsBindableProxyFactory bindableProxyFactory,
-																	StreamFunctionProperties streamFunctionProperties) {
-		return new KafkaStreamsFunctionProcessor(bindingServiceProperties, kafkaStreamsExtendedBindingProperties,
-				keyValueSerdeResolver, kafkaStreamsBindingInformationCatalogue, kafkaStreamsMessageConversionDelegate,
-				cleanupConfig.getIfUnique(), bindableProxyFactory, streamFunctionProperties);
-	}
-
-	@Bean
 	public KafkaStreamsMessageConversionDelegate messageConversionDelegate(
 																		CompositeMessageConverter compositeMessageConverter,
 																		SendToDlqAndContinue sendToDlqAndContinue,
@@ -358,6 +343,21 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 	@Bean("kafkaStreamsDlqDispatchers")
 	public Map<String, KafkaStreamsDlqDispatch> dlqDispatchers() {
 		return new HashMap<>();
+	}
+
+	@Bean
+	@Conditional(FunctionDetectorCondition.class)
+	public KafkaStreamsFunctionProcessor kafkaStreamsFunctionProcessor(BindingServiceProperties bindingServiceProperties,
+																	   KafkaStreamsExtendedBindingProperties kafkaStreamsExtendedBindingProperties,
+																	   KeyValueSerdeResolver keyValueSerdeResolver,
+																	   KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue,
+																	   KafkaStreamsMessageConversionDelegate kafkaStreamsMessageConversionDelegate,
+																	   ObjectProvider<CleanupConfig> cleanupConfig,
+																	   KafkaStreamsBindableProxyFactory bindableProxyFactory,
+																	   StreamFunctionProperties streamFunctionProperties) {
+		return new KafkaStreamsFunctionProcessor(bindingServiceProperties, kafkaStreamsExtendedBindingProperties,
+				keyValueSerdeResolver, kafkaStreamsBindingInformationCatalogue, kafkaStreamsMessageConversionDelegate,
+				cleanupConfig.getIfUnique(), bindableProxyFactory, streamFunctionProperties);
 	}
 
 }


### PR DESCRIPTION
Use BeanFactoryUtils.beanNamesForTypeIncludingAncestors instead of
getBean from BeanFactory which forces the bean creation inside the
function detector condition. There was a race condition in which
applications were unable to autowire beans and use them in functions
while the detector condition was creating the beans. This change will
delay the creation of the function bean until it is needed.