### PR TITLE
Introducing retry for finding state stores.

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -952,6 +952,16 @@ ReadOnlyKeyValueStore<Object, Object> keyValueStore =
 						interactiveQueryService.getQueryableStoreType("my-store", QueryableStoreTypes.keyValueStore());
 ----
 
+During the startup, the above method call to retrieve the startup might fail.
+For e.g it might still be in the middle of initializing the state store.
+In such cases, it will be useful to retry this operation.
+Kafka Streams binder provides a simple retry mechanism to accommodate this.
+
+Following are the two properties that you can use to control this retrying.
+
+* spring.cloud.stream.binder.kafka.streams.stateStoreRetry.maxAttempts - Default is `1` .
+* spring.cloud.stream.binder.kafka.streams.stateStoreRetry.backOffInterval - Default is `1000` milliseconds.
+
 If there are multiple instances of the kafka streams application running, then before you can query them interactively, you need to identify which application instance hosts the key.
 `InteractiveQueryService` API provides methods for identifying the host information.
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/properties/KafkaStreamsBinderConfigurationProperties.java
@@ -54,6 +54,16 @@ public class KafkaStreamsBinderConfigurationProperties
 
 	private String applicationId;
 
+	private StateStoreRetry stateStoreRetry = new StateStoreRetry();
+
+	public StateStoreRetry getStateStoreRetry() {
+		return stateStoreRetry;
+	}
+
+	public void setStateStoreRetry(StateStoreRetry stateStoreRetry) {
+		this.stateStoreRetry = stateStoreRetry;
+	}
+
 	public String getApplicationId() {
 		return this.applicationId;
 	}
@@ -77,6 +87,29 @@ public class KafkaStreamsBinderConfigurationProperties
 	public void setSerdeError(
 			KafkaStreamsBinderConfigurationProperties.SerdeError serdeError) {
 		this.serdeError = serdeError;
+	}
+
+	public static class StateStoreRetry {
+
+		private int maxAttempts = 1;
+
+		private long backoffPeriod = 1000;
+
+		public int getMaxAttempts() {
+			return maxAttempts;
+		}
+
+		public void setMaxAttempts(int maxAttempts) {
+			this.maxAttempts = maxAttempts;
+		}
+
+		public long getBackoffPeriod() {
+			return backoffPeriod;
+		}
+
+		public void setBackoffPeriod(long backoffPeriod) {
+			this.backoffPeriod = backoffPeriod;
+		}
 	}
 
 }


### PR DESCRIPTION
During application startup, there are cases when state stores
might take longer time to initialize. The call to find the
state store in the binder (InteractiveQueryService) will fail in
those situations. Providing a basic retry mechanism using which
applicaitons can opt-in for this retry.

Adding properties for retrying state store at the binder level.
Adding docs.
Polishing.

Resolves #706