### PR TITLE
Multi binder issues for Kafka Streams table types

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinderConfiguration.java
@@ -21,13 +21,16 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.cloud.stream.annotation.BindingProvider;
 import org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * Configuration for GlobalKTable binder.
@@ -37,13 +40,9 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @BindingProvider
+@Import({ KafkaAutoConfiguration.class,
+		KafkaStreamsBinderHealthIndicatorConfiguration.class })
 public class GlobalKTableBinderConfiguration {
-
-	@Bean
-	@ConditionalOnBean(name = "outerContext")
-	public static BeanFactoryPostProcessor outerContextBeanFactoryPostProcessor() {
-		return KafkaStreamsBinderUtils.outerContextBeanFactoryPostProcessor();
-	}
 
 	@Bean
 	public KafkaTopicProvisioner provisioningProvider(
@@ -63,6 +62,26 @@ public class GlobalKTableBinderConfiguration {
 		globalKTableBinder.setKafkaStreamsExtendedBindingProperties(
 				kafkaStreamsExtendedBindingProperties);
 		return globalKTableBinder;
+	}
+
+	@Bean
+	@ConditionalOnBean(name = "outerContext")
+	public static BeanFactoryPostProcessor outerContextBeanFactoryPostProcessor() {
+		return beanFactory -> {
+
+			// It is safe to call getBean("outerContext") here, because this bean is
+			// registered as first
+			// and as independent from the parent context.
+			ApplicationContext outerContext = (ApplicationContext) beanFactory
+					.getBean("outerContext");
+			beanFactory.registerSingleton(
+					KafkaStreamsBinderConfigurationProperties.class.getSimpleName(),
+					outerContext
+							.getBean(KafkaStreamsBinderConfigurationProperties.class));
+			beanFactory.registerSingleton(
+					KafkaStreamsExtendedBindingProperties.class.getSimpleName(),
+					outerContext.getBean(KafkaStreamsExtendedBindingProperties.class));
+		};
 	}
 
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinderConfiguration.java
@@ -21,13 +21,16 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.cloud.stream.annotation.BindingProvider;
 import org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * Configuration for KTable binder.
@@ -37,13 +40,9 @@ import org.springframework.context.annotation.Configuration;
 @SuppressWarnings("ALL")
 @Configuration
 @BindingProvider
+@Import({ KafkaAutoConfiguration.class,
+		KafkaStreamsBinderHealthIndicatorConfiguration.class })
 public class KTableBinderConfiguration {
-
-	@Bean
-	@ConditionalOnBean(name = "outerContext")
-	public static BeanFactoryPostProcessor outerContextBeanFactoryPostProcessor() {
-		return KafkaStreamsBinderUtils.outerContextBeanFactoryPostProcessor();
-	}
 
 	@Bean
 	public KafkaTopicProvisioner provisioningProvider(
@@ -63,5 +62,26 @@ public class KTableBinderConfiguration {
 		kTableBinder.setKafkaStreamsExtendedBindingProperties(kafkaStreamsExtendedBindingProperties);
 		return kTableBinder;
 	}
+
+	@Bean
+	@ConditionalOnBean(name = "outerContext")
+	public static BeanFactoryPostProcessor outerContextBeanFactoryPostProcessor() {
+		return beanFactory -> {
+
+			// It is safe to call getBean("outerContext") here, because this bean is
+			// registered as first
+			// and as independent from the parent context.
+			ApplicationContext outerContext = (ApplicationContext) beanFactory
+					.getBean("outerContext");
+			beanFactory.registerSingleton(
+					KafkaStreamsBinderConfigurationProperties.class.getSimpleName(),
+					outerContext
+							.getBean(KafkaStreamsBinderConfigurationProperties.class));
+			beanFactory.registerSingleton(
+					KafkaStreamsExtendedBindingProperties.class.getSimpleName(),
+					outerContext.getBean(KafkaStreamsExtendedBindingProperties.class));
+		};
+	}
+
 
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
@@ -20,14 +20,12 @@ import java.util.Map;
 
 import org.apache.kafka.streams.kstream.KStream;
 
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsConsumerProperties;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.MethodParameter;
 import org.springframework.util.StringUtils;
 
@@ -92,20 +90,4 @@ final class KafkaStreamsBinderUtils {
 		return KStream.class.isAssignableFrom(targetBeanClass)
 				&& KStream.class.isAssignableFrom(methodParameter.getParameterType());
 	}
-
-	static BeanFactoryPostProcessor outerContextBeanFactoryPostProcessor() {
-		return (beanFactory) -> {
-			// It is safe to call getBean("outerContext") here, because this bean is
-			// registered first and is independent from the parent context.
-			GenericApplicationContext outerContext = (GenericApplicationContext) beanFactory
-					.getBean("outerContext");
-
-			outerContext.registerBean(KafkaStreamsBinderConfigurationProperties.class,
-					() -> outerContext.getBean(KafkaStreamsBinderConfigurationProperties.class));
-			outerContext.registerBean(KafkaStreamsBindingInformationCatalogue.class,
-					() -> outerContext.getBean(KafkaStreamsBindingInformationCatalogue.class));
-
-		};
-	}
-
 }


### PR DESCRIPTION
When KTable or GlobalKTable binders are used in a multi bindder
environment, it has difficulty finding certain beans/properties.
Addressing this issue.

Adding tests.

Resolves #681