### PR TITLE
State store beans registered with StreamListener

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -942,7 +942,22 @@ public KStream<?, WordCount> process(KStream<Object, String> input) {
 === State Store
 
 State store is created automatically by Kafka Streams when the DSL is used.
-When processor API is used, you need to register a state store manually. In order to do so, you can use `KafkaStreamsStateStore` annotation.
+When processor API is used, you need to register a state store manually. In order to do so, you can create the StateStore as a bean in the application.
+Here is an example of defining such a bean.
+
+```
+@Bean
+public StoreBuilder mystore() {
+    return Stores.windowStoreBuilder(
+            Stores.persistentWindowStore("mystate",
+                    3L, 3, 3L, false), Serdes.String(),
+            Serdes.String());
+}
+```
+
+During the bootstrap, the above bean will be processed by the binder and pass on to the Streams builder object.
+Defining custom state stores by providing them as beans is the preferred approach.
+However, you can also use `KafkaStreamsStateStore` annotation for this.
 You can specify the name and type of the store, flags to control log and disabling cache, etc.
 Once the store is created by the binder during the bootstrapping phase, you can access this state store through the processor API.
 Below are some primitives for doing this.

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.stream.binder.kafka.streams;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +30,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -371,24 +369,7 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator extends AbstractKafkaStr
 				LOG.info("state store " + storeBuilder.name() + " added to topology");
 			}
 		}
-		String[] bindingTargets = StringUtils.commaDelimitedListToStringArray(
-				this.bindingServiceProperties.getBindingDestination(inboundName));
-
-		KStream<?, ?> stream = streamsBuilder.stream(Arrays.asList(bindingTargets),
-				Consumed.with(keySerde, valueSerde)
-						.withOffsetResetPolicy(autoOffsetReset));
-		final boolean nativeDecoding = this.bindingServiceProperties
-				.getConsumerProperties(inboundName).isUseNativeDecoding();
-		if (nativeDecoding) {
-			LOG.info("Native decoding is enabled for " + inboundName
-					+ ". Inbound deserialization done at the broker.");
-		}
-		else {
-			LOG.info("Native decoding is disabled for " + inboundName
-					+ ". Inbound message conversion done by Spring Cloud Stream.");
-		}
-
-		return getkStream(bindingProperties, stream, nativeDecoding);
+		return getKStream(inboundName, bindingProperties, streamsBuilder, keySerde, valueSerde, autoOffsetReset);
 	}
 
 	private void validateStreamListenerMethod(StreamListener streamListener,


### PR DESCRIPTION
When StreamListener based processors used in Kafka Streams
applications, it is not possible to register state store beans
using StateStoreBuilder. This is allowed in the functional model.
This method of providing custom state stores is desired as this
gives the user more flexibility in configuring Serde's and other
properties on the state store. Adding this feature to StreamListner
based Kafka Streams processors.

Adding test to verify.

Adding docs.

Resolves #676