### PR TITLE
Kafka Streams binder metrics

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1064,3 +1064,24 @@ Here is an example of using custom state stores with functional style described 
 ----
 
 These state stores can be then accessed by the applications directly.
+
+==== Accessing Kafka Streams Metrics
+
+Spring Cloud Stream Kafka Streams binder provides a basic mechanism for accessing Kafka Streams metrics exported through a MircoMeter `MeterRegistry`.
+Kafka Streams metrics that are available through `KafkaStreams#metrics()` are exported to this meter registry by the binder.
+The metrics exported are from the consumers, producers, admin-client and the stream itself.
+
+The metrics exported by the binder are exported with the format of metrics group name followed by a dot and then the actual metric name.
+All dashes in the original metric information is replaced with dots.
+
+For e.g. the metric name `network-io-total` from the metric group `consumer-metrics` is available in the micrometer registry as `consumer.metrics.network.io.total`.
+Similarly, the metric `commit-total` from `stream-metrics` is available as `stream.metrics.commit.total`.
+
+You can either programmatically access the Micrometer `MeterRegistry` in the application and then iterate through the available gauges or use Spring Boot actuator to access the metrics through a REST endpoint.
+When accessing through the Boot actuator endpoint, make sure to add `metrics` to the property `management.endpoints.web.exposure.include`.
+Then you can access `/acutator/metrics` to get a list of all the available metrics which then can be individually accessed through the same URL (`/actuator/metrics/<metric-name>`).
+
+Anything beyond the info level metrics available through `KafkaStreams#metrics()`, (for e.g. the debugging level metrics) are still only available through JMX after you set the `metrics.recording.level` to `DEBUG`.
+Kafka Streams, by default, set this level to `INFO`.
+https://kafka.apache.org/documentation/#kafka_streams_monitoring[Please see this section] from Kafka Streams documentation for more details.
+In a future release, binder may support exporting these DEBUG level metrics as well through Micrometer.

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderMetrics.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderMetrics.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.streams;
+
+import java.util.Map;
+import java.util.function.ToDoubleFunction;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.streams.KafkaStreams;
+
+/**
+ * Kafka Streams binder metrics implementation that exports the metrics available
+ * through {@link KafkaStreams#metrics()} into a micrometer {@link io.micrometer.core.instrument.MeterRegistry}.
+ *
+ * @author Soby Chacko
+ * @since 3.0.0
+ */
+public class KafkaStreamsBinderMetrics {
+
+	private KafkaStreams kafkaStreams;
+
+	private final MeterRegistry meterRegistry;
+
+	private MeterBinder meterBinder;
+
+	public KafkaStreamsBinderMetrics(MeterRegistry meterRegistry) {
+		this.meterRegistry = meterRegistry;
+	}
+
+	public void bindTo(MeterRegistry meterRegistry) {
+		if (this.meterBinder == null) {
+			this.meterBinder = new MeterBinder() {
+				@Override
+				@SuppressWarnings("unchecked")
+				public void bindTo(MeterRegistry registry) {
+					if (KafkaStreamsBinderMetrics.this.kafkaStreams != null) {
+						final Map<MetricName, ? extends Metric> metrics = KafkaStreamsBinderMetrics.this.kafkaStreams.metrics();
+
+						for (Map.Entry<MetricName, ? extends Metric> metric : metrics.entrySet()) {
+							final Gauge.Builder<KafkaStreamsBinderMetrics> builder =
+									Gauge.builder(sanitize(metric.getKey().group() + "." + metric.getKey().name()), this,
+											toDoubleFunction(metric.getValue()));
+							final Map<String, String> tags = metric.getKey().tags();
+							for (Map.Entry<String, String> tag : tags.entrySet()) {
+								builder.tag(tag.getKey(), tag.getValue());
+							}
+							builder.description(metric.getKey().description())
+									.register(meterRegistry);
+						}
+					}
+				}
+
+				ToDoubleFunction toDoubleFunction(Metric metric) {
+					return (o) -> {
+						if (metric.metricValue() instanceof Number) {
+							return (Double) metric.metricValue();
+						}
+						else {
+							return 0.0;
+						}
+					};
+				}
+			};
+		}
+		this.meterBinder.bindTo(this.meterRegistry);
+	}
+
+	public void addMetrics(KafkaStreams kafkaStreams) {
+		synchronized (KafkaStreamsBinderMetrics.this) {
+			this.kafkaStreams = kafkaStreams;
+			this.bindTo(this.meterRegistry);
+		}
+	}
+
+	private static String sanitize(String value) {
+		return value.replaceAll("-", ".");
+	}
+}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsRegistry.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsRegistry.java
@@ -29,6 +29,12 @@ import org.apache.kafka.streams.KafkaStreams;
  */
 class KafkaStreamsRegistry {
 
+	private final KafkaStreamsBinderMetrics kafkaStreamsBinderMetrics;
+
+	KafkaStreamsRegistry(KafkaStreamsBinderMetrics kafkaStreamsBinderMetrics) {
+		this.kafkaStreamsBinderMetrics = kafkaStreamsBinderMetrics;
+	}
+
 	private final Set<KafkaStreams> kafkaStreams = new HashSet<>();
 
 	Set<KafkaStreams> getKafkaStreams() {
@@ -40,6 +46,7 @@ class KafkaStreamsRegistry {
 	 * @param kafkaStreams {@link KafkaStreams} object created in the application
 	 */
 	void registerKafkaStreams(KafkaStreams kafkaStreams) {
+		this.kafkaStreamsBinderMetrics.addMetrics(kafkaStreams);
 		this.kafkaStreams.add(kafkaStreams);
 	}
 

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsInteractiveQueryIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsInteractiveQueryIntegrationTests.java
@@ -95,7 +95,8 @@ public class KafkaStreamsInteractiveQueryIntegrationTests {
 	public void testStateStoreRetrievalRetry() {
 
 		KafkaStreams mock = Mockito.mock(KafkaStreams.class);
-		KafkaStreamsRegistry kafkaStreamsRegistry = new KafkaStreamsRegistry();
+		KafkaStreamsBinderMetrics mockMetrics = Mockito.mock(KafkaStreamsBinderMetrics.class);
+		KafkaStreamsRegistry kafkaStreamsRegistry = new KafkaStreamsRegistry(mockMetrics);
 		kafkaStreamsRegistry.registerKafkaStreams(mock);
 		KafkaStreamsBinderConfigurationProperties binderConfigurationProperties =
 				new KafkaStreamsBinderConfigurationProperties(new KafkaProperties());
@@ -140,8 +141,7 @@ public class KafkaStreamsInteractiveQueryIntegrationTests {
 		}
 	}
 
-	private void receiveAndValidateFoo(ConfigurableApplicationContext context)
-			throws Exception {
+	private void receiveAndValidateFoo(ConfigurableApplicationContext context) {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
 		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(
 				senderProps);

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.mock;
  * @author Thomas Cheyney
  * @author Soby Chacko
  */
-public class KafkaBinderMetricsTest {
+public class 	KafkaBinderMetricsTest {
 
 	private static final String TEST_TOPIC = "test";
 


### PR DESCRIPTION
Export Kafka Streams metrics available through KafkaStreams#metrics into a Micrometer MeterRegistry.
Add documentation for how to access metrics.
Modify test to verify metrics.

Resolves #543