### PR TITLE
GH-628: Add dlqPartitions property

### DIFF
--- a/docs/src/main/asciidoc/dlq.adoc
+++ b/docs/src/main/asciidoc/dlq.adoc
@@ -22,6 +22,8 @@ public DlqPartitionFunction partitionFunction() {
 ----
 ====
 
+NOTE: If you set a consumer binding's `dlqPartitions` property to 1 (and the binder's `minPartitionCount` is equal to `1`), there is no need to supply a `DlqPartitionFunction`; the framework will always use partition 0.
+If you set a consumer binding's `dlqPartitions` property to a value greater than `1` (or the binder's `minPartitionCount` is greater than `1`), you **must** provide a `DlqPartitionFunction` bean, even if the partition count is the same as the original topic's.
 
 [[dlq-handling]]
 ==== Handling Records in a Dead-Letter Topic

--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -213,6 +213,15 @@ See <<dlq-partition-selection>> for how to change that behavior.
 **Not allowed when `destinationIsPattern` is `true`.**
 +
 Default: `false`.
+dlqPartitions::
+When `enableDlq` is true, and this property is not set, a dead letter topic with the same number of partitions as the primary topic(s) is created.
+Usually, dead-letter records are sent to the same partition in the dead-letter topic as the original record.
+This behavior can be changed; see <<dlq-partition-selection>>.
+If this property is set to `1` and there is no `DqlPartitionFunction` bean, all dead-letter records will be written to partition `0`.
+If this property is greater than `1`, you **MUST** provide a `DlqPartitionFunction` bean.
+Note that the actual partition count is affected by the binder's `minPartitionCount` property.
++
+Default: `none`
 configuration::
 Map with a key/value pair containing generic Kafka consumer properties.
 In addition to having Kafka consumer properties, other configuration properties can be passed here.

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
@@ -100,6 +100,8 @@ public class KafkaConsumerProperties {
 
 	private String dlqName;
 
+	private Integer dlqPartitions;
+
 	private KafkaProducerProperties dlqProducerProperties = new KafkaProducerProperties();
 
 	private int recoveryInterval = 5000;
@@ -213,6 +215,14 @@ public class KafkaConsumerProperties {
 
 	public void setDlqName(String dlqName) {
 		this.dlqName = dlqName;
+	}
+
+	public Integer getDlqPartitions() {
+		return this.dlqPartitions;
+	}
+
+	public void setDlqPartitions(Integer dlqPartitions) {
+		this.dlqPartitions = dlqPartitions;
 	}
 
 	public String[] getTrustedPackages() {

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
@@ -274,12 +274,16 @@ public class KafkaTopicProvisioner implements
 	private ConsumerDestination createDlqIfNeedBe(AdminClient adminClient, String name,
 			String group, ExtendedConsumerProperties<KafkaConsumerProperties> properties,
 			boolean anonymous, int partitions) {
+
 		if (properties.getExtension().isEnableDlq() && !anonymous) {
 			String dlqTopic = StringUtils.hasText(properties.getExtension().getDlqName())
 					? properties.getExtension().getDlqName()
 					: "error." + name + "." + group;
+			int dlqPartitions = properties.getExtension().getDlqPartitions() == null
+					? partitions
+					: properties.getExtension().getDlqPartitions();
 			try {
-				createTopicAndPartitions(adminClient, dlqTopic, partitions,
+				createTopicAndPartitions(adminClient, dlqTopic, dlqPartitions,
 						properties.getExtension().isAutoRebalanceEnabled(),
 						properties.getExtension().getTopic());
 			}


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/628

Allow users to specify the number of partitions in the dead letter topic.

If the property is set to 1 and the `minPartitionCount` binder property is 1,
override the default behavior and always publish to partition 0.