### PR TITLE
Fixed log message to print as value vs key serde

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -128,7 +128,7 @@ class KStreamBinder extends
 		else {
 			valueSerde = Serdes.ByteArray();
 		}
-		LOG.info("Key Serde used for (outbound) " + name + ": " + valueSerde.getClass().getName());
+		LOG.info("Value Serde used for (outbound) " + name + ": " + valueSerde.getClass().getName());
 
 		to(properties.isUseNativeEncoding(), name, outboundBindTarget,
 				(Serde<Object>) keySerde, (Serde<Object>) valueSerde, properties.getExtension());


### PR DESCRIPTION
This change will fix the log message. Currently, it is misleading as it is writing value serde detail for keyserde