### PR TITLE
Always call value serde configure method

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
@@ -184,7 +184,6 @@ public class KeyValueSerdeResolver implements ApplicationContextAware {
 			else {
 				valueSerde = Serdes.ByteArray();
 			}
-			valueSerde.configure(this.streamConfigGlobalProperties, false);
 		}
 		catch (ClassNotFoundException ex) {
 			throw new IllegalStateException("Serde class not found: ", ex);
@@ -203,7 +202,6 @@ public class KeyValueSerdeResolver implements ApplicationContextAware {
 			else {
 				valueSerde = Serdes.ByteArray();
 			}
-			valueSerde.configure(this.streamConfigGlobalProperties, false);
 		}
 		catch (ClassNotFoundException ex) {
 			throw new IllegalStateException("Serde class not found: ", ex);

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KeyValueSerdeResolver.java
@@ -125,7 +125,6 @@ public class KeyValueSerdeResolver implements ApplicationContextAware {
 			else {
 				valueSerde = Serdes.ByteArray();
 			}
-			valueSerde.configure(this.streamConfigGlobalProperties, false);
 		}
 		catch (ClassNotFoundException ex) {
 			throw new IllegalStateException("Serde class not found: ", ex);
@@ -146,7 +145,6 @@ public class KeyValueSerdeResolver implements ApplicationContextAware {
 			else {
 				valueSerde = Serdes.ByteArray();
 			}
-			valueSerde.configure(this.streamConfigGlobalProperties, false);
 		}
 		catch (ClassNotFoundException ex) {
 			throw new IllegalStateException("Serde class not found: ", ex);
@@ -393,6 +391,7 @@ public class KeyValueSerdeResolver implements ApplicationContextAware {
 		else {
 			valueSerde = getFallbackSerde("default.value.serde");
 		}
+		valueSerde.configure(this.streamConfigGlobalProperties, false);
 		return valueSerde;
 	}
 
@@ -425,6 +424,7 @@ public class KeyValueSerdeResolver implements ApplicationContextAware {
 				valueSerde = Serdes.ByteArray();
 			}
 		}
+		valueSerde.configure(streamConfigGlobalProperties, false);
 		return valueSerde;
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/836

The value serde was being configured in the wrong place, which was skipping it for state stores. Moved the call to the `getValueSerde` method to make sure it's always configured.