### PR TITLE
GH-657: DLQ producer properties from the binder

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -1079,10 +1079,16 @@ public class KafkaMessageChannelBinder extends
 
 				if (properties.isUseNativeDecoding()) {
 					if (record != null) {
-						Map<String, String> configuration = transMan == null
+						// Give the binder configuration the least preference.
+						Map<String, String> configuration = this.configurationProperties.getConfiguration();
+						// Then give any producer specific properties specified on the binder.
+						configuration.putAll(this.configurationProperties.getProducerProperties());
+						Map<String, String> configs = transMan == null
 								? dlqProducerProperties.getConfiguration()
 								: this.configurationProperties.getTransaction()
-										.getProducer().getConfiguration();
+								.getProducer().getConfiguration();
+						// Finally merge with dlq producer properties or the transaction producer properties.
+						configuration.putAll(configs);
 						if (record.key() != null
 								&& !record.key().getClass().isInstance(byte[].class)) {
 							ensureDlqMessageCanBeProperlySerialized(configuration,


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/657

Adding the ability for the binder to detect DLQ producer properties
set on the binder as common producer properties.

Adding test to verify.