### PR TITLE
Reject improper settings for bootstrap.servers

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -226,6 +226,7 @@ configuration::
 Map with a key/value pair containing generic Kafka consumer properties.
 In addition to having Kafka consumer properties, other configuration properties can be passed here.
 For example some properties needed by the application such as `spring.cloud.stream.kafka.bindings.input.consumer.configuration.foo=bar`.
+The `bootstrap.servers` property cannot be set here; use multi-binder support if you need to connect to multiple clusters.
 +
 Default: Empty map.
 dlqName::
@@ -354,6 +355,7 @@ For example `!ask,as*` will pass `ash` but not `ask`.
 Default: `*` (all headers - except the `id` and `timestamp`)
 configuration::
 Map with a key/value pair containing generic Kafka producer properties.
+The `bootstrap.servers` property cannot be set here; use multi-binder support if you need to connect to multiple clusters.
 +
 Default: Empty map.
 topic.properties::

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -63,6 +64,7 @@ import org.springframework.kafka.core.CleanupConfig;
 import org.springframework.kafka.streams.RecoveringDeserializationExceptionHandler;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -238,8 +240,11 @@ public abstract class AbstractKafkaStreamsBinderProcessor implements Application
 		//spring.cloud.stream.kafka.streams.binder.functions.process.configuration.num.threads (assuming that process is the function name).
 		KafkaStreamsConsumerProperties extendedConsumerProperties = this.kafkaStreamsExtendedBindingProperties
 				.getExtendedConsumerProperties(inboundName);
-		streamConfigGlobalProperties
-				.putAll(extendedConsumerProperties.getConfiguration());
+		Map<String, String> bindingConfig = extendedConsumerProperties.getConfiguration();
+		Assert.state(!bindingConfig.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
+				ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG + " cannot be overridden at the binding level; "
+						+ "use multiple binders instead");
+		streamConfigGlobalProperties.putAll(bindingConfig);
 
 		String bindingLevelApplicationId = extendedConsumerProperties.getApplicationId();
 		// override application.id if set at the individual binding level.

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
@@ -43,6 +43,7 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -154,8 +155,12 @@ final class KafkaStreamsBinderUtils {
 			props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG,
 					producerProperties.getExtension().getCompressionType().toString());
 		}
-		if (!ObjectUtils.isEmpty(producerProperties.getExtension().getConfiguration())) {
-			props.putAll(producerProperties.getExtension().getConfiguration());
+		Map<String, String> configs = producerProperties.getExtension().getConfiguration();
+		Assert.state(!configs.containsKey(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
+				ProducerConfig.BOOTSTRAP_SERVERS_CONFIG + " cannot be overridden at the binding level; "
+						+ "use multiple binders instead");
+		if (!ObjectUtils.isEmpty(configs)) {
+			props.putAll(configs);
 		}
 		// Always send as byte[] on dlq (the same byte[] that the consumer received)
 		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/875

- the `bootstrap.servers` property cannot be overridden at the binding level.