### PR TITLE
Update s-c-build to 2.3.0 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>3.0.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-kafka.version>2.5.0.RELEASE</spring-kafka.version>
-		<spring-integration-kafka.version>3.3.0.RELEASE</spring-integration-kafka.version>
+		<spring-integration-kafka.version>3.2.1.RELEASE</spring-integration-kafka.version>
 		<kafka.version>2.5.0</kafka.version>
 		<spring-cloud-schema-registry.version>1.0.5.BUILD-SNAPSHOT</spring-cloud-schema-registry.version>
 		<spring-cloud-stream.version>3.0.5.BUILD-SNAPSHOT</spring-cloud-stream.version>


### PR DESCRIPTION
* Spring Kafka -> 2.5.0
* Kafka client -> 2.5.0
* Keep SIK at 3.2.1

Kafka Streams binder health indicator changes to make it work
backward compatible with kafka clients lower than 2.5.0. This
is done by introducing a reflective call into a method in
KafkaStreams$State.