### PR TITLE
Configuring Kafka producer timeout

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -395,6 +395,11 @@ If you override the `kafka-clients` jar to 2.1.0 (or later), as discussed in the
 +
 Default: `none`.
 
+closeTimeout::
+Timeout in number of seconds to wait for when closing the producer.
++
+Default: `30`
+
 ==== Usage examples
 
 In this section, we show the use of the preceding properties for specific scenarios.

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaProducerProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaProducerProperties.java
@@ -95,6 +95,12 @@ public class KafkaProducerProperties {
 	private String recordMetadataChannel;
 
 	/**
+	 * Timeout value in seconds for the duration to wait when closing the producer.
+	 * If not set this defaults to 30 seconds.
+	 */
+	private int closeTimeout;
+
+	/**
 	 * @return buffer size
 	 *
 	 * Upper limit, in bytes, of how much data the Kafka producer attempts to batch before sending.
@@ -242,6 +248,17 @@ public class KafkaProducerProperties {
 
 	public void setRecordMetadataChannel(String recordMetadataChannel) {
 		this.recordMetadataChannel = recordMetadataChannel;
+	}
+
+	/**
+	 * @return timeout in seconds for closing the producer
+	 */
+	public int getCloseTimeout() {
+		return this.closeTimeout;
+	}
+
+	public void setCloseTimeout(int closeTimeout) {
+		this.closeTimeout = closeTimeout;
 	}
 
 	/**

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -490,25 +490,29 @@ public class KafkaMessageChannelBinder extends
 			props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
 					this.configurationProperties.getKafkaConnectionString());
 		}
+		final KafkaProducerProperties kafkaProducerProperties = producerProperties.getExtension();
 		if (ObjectUtils.isEmpty(props.get(ProducerConfig.BATCH_SIZE_CONFIG))) {
 			props.put(ProducerConfig.BATCH_SIZE_CONFIG,
-					String.valueOf(producerProperties.getExtension().getBufferSize()));
+					String.valueOf(kafkaProducerProperties.getBufferSize()));
 		}
 		if (ObjectUtils.isEmpty(props.get(ProducerConfig.LINGER_MS_CONFIG))) {
 			props.put(ProducerConfig.LINGER_MS_CONFIG,
-					String.valueOf(producerProperties.getExtension().getBatchTimeout()));
+					String.valueOf(kafkaProducerProperties.getBatchTimeout()));
 		}
 		if (ObjectUtils.isEmpty(props.get(ProducerConfig.COMPRESSION_TYPE_CONFIG))) {
 			props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG,
-					producerProperties.getExtension().getCompressionType().toString());
+					kafkaProducerProperties.getCompressionType().toString());
 		}
-		if (!ObjectUtils.isEmpty(producerProperties.getExtension().getConfiguration())) {
-			props.putAll(producerProperties.getExtension().getConfiguration());
+		if (!ObjectUtils.isEmpty(kafkaProducerProperties.getConfiguration())) {
+			props.putAll(kafkaProducerProperties.getConfiguration());
 		}
 		DefaultKafkaProducerFactory<byte[], byte[]> producerFactory = new DefaultKafkaProducerFactory<>(
 				props);
 		if (transactionIdPrefix != null) {
 			producerFactory.setTransactionIdPrefix(transactionIdPrefix);
+		}
+		if (kafkaProducerProperties.getCloseTimeout() > 0) {
+			producerFactory.setPhysicalCloseTimeout(kafkaProducerProperties.getCloseTimeout());
 		}
 		return producerFactory;
 	}

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationPropertiesTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderConfigurationPropertiesTest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.binder.kafka;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,7 @@ public class KafkaBinderConfigurationPropertiesTest {
 		KafkaProducerProperties kafkaProducerProperties = new KafkaProducerProperties();
 		kafkaProducerProperties.setBufferSize(12345);
 		kafkaProducerProperties.setBatchTimeout(100);
+		kafkaProducerProperties.setCloseTimeout(10);
 		kafkaProducerProperties
 				.setCompressionType(KafkaProducerProperties.CompressionType.gzip);
 		ExtendedProducerProperties<KafkaProducerProperties> producerProperties = new ExtendedProducerProperties<>(
@@ -84,6 +86,14 @@ public class KafkaBinderConfigurationPropertiesTest {
 		assertThat(producerConfigs.get("value.serializer"))
 				.isEqualTo(ByteArraySerializer.class);
 		assertThat(producerConfigs.get("compression.type")).isEqualTo("gzip");
+
+		Field physicalCloseTimeoutField = ReflectionUtils
+				.findField(DefaultKafkaProducerFactory.class, "physicalCloseTimeout", Duration.class);
+		ReflectionUtils.makeAccessible(physicalCloseTimeoutField);
+		Duration physicalCloseTimeoutConfig = (Duration) ReflectionUtils
+				.getField(physicalCloseTimeoutField, producerFactory);
+		assertThat(physicalCloseTimeoutConfig).isEqualTo(Duration.ofSeconds(10));
+
 		List<String> bootstrapServers = new ArrayList<>();
 		bootstrapServers.add("10.98.09.199:9082");
 		assertThat((((String) producerConfigs.get("bootstrap.servers"))


### PR DESCRIPTION
Allow setting timeout for closing the producer.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/891