### PR TITLE
GH-914: Add Micrometer Producer/Consumer Listeners

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/StreamsListener.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/StreamsListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.streams;
+
+import org.apache.kafka.streams.KafkaStreams;
+
+/**
+ * Temporary workaround until SK 2.5.3 is available.
+ *
+ * @author Gary Russell
+ * @since 3.0.6
+ *
+ */
+interface StreamsListener {
+
+	/**
+	 * A new {@link KafkaStreams} was created.
+	 * @param id the streams id (factory bean name).
+	 * @param streams the streams;
+	 */
+	default void streamsAdded(String id, KafkaStreams streams) {
+	}
+
+	/**
+	 * An existing {@link KafkaStreams} was removed.
+	 * @param id the streams id (factory bean name).
+	 * @param streams the streams;
+	 */
+	default void streamsRemoved(String id, KafkaStreams streams) {
+	}
+
+}

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/ClientFactoryCustomizer.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/ClientFactoryCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.config;
+
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.ProducerFactory;
+
+/**
+ * Called by the binder to customize the factories.
+ *
+ * @author Gary Russell
+ * @since 3.0.6
+ *
+ */
+public interface ClientFactoryCustomizer {
+
+	default void configure(ProducerFactory<?, ?> pf) {
+	}
+
+	default void configure(ConsumerFactory<?, ?> cf) {
+	}
+
+}

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderUnitTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderUnitTests.java
@@ -237,7 +237,7 @@ public class KafkaBinderUnitTests {
 			@Override
 			protected ConsumerFactory<?, ?> createKafkaConsumerFactory(boolean anonymous,
 					String consumerGroup,
-					ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties) {
+					ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties, String beanName) {
 
 				return new ConsumerFactory<byte[], byte[]>() {
 

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaTransactionTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaTransactionTests.java
@@ -91,10 +91,10 @@ public class KafkaTransactionTests {
 			@Override
 			protected DefaultKafkaProducerFactory<byte[], byte[]> getProducerFactory(
 					String transactionIdPrefix,
-					ExtendedProducerProperties<KafkaProducerProperties> producerProperties) {
+					ExtendedProducerProperties<KafkaProducerProperties> producerProperties, String beanName) {
 				DefaultKafkaProducerFactory<byte[], byte[]> producerFactory = spy(
 						super.getProducerFactory(transactionIdPrefix,
-								producerProperties));
+								producerProperties, beanName));
 				willReturn(mockProducer).given(producerFactory).createProducer("foo-");
 				return producerFactory;
 			}


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/914

Boot no longer uses the deprecated JMX MBean scraping provided by Micrometer.

Add configuration to add Micrometer Meters when Micrometer and spring-kafka 2.5.x are on
the class path.