### PR TITLE
GH-935: Fix KafkaNullConverter supported MimeType

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaNullConverter.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaNullConverter.java
@@ -23,6 +23,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.AbstractMessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.util.MimeTypeUtils;
 
 /**
  * A {@link MessageConverter} that supports {@link KafkaNull} payloads.
@@ -34,7 +35,7 @@ import org.springframework.messaging.converter.MessageConverter;
 public class KafkaNullConverter extends AbstractMessageConverter {
 
 	public KafkaNullConverter() {
-		super(Collections.emptyList());
+		super(Collections.singletonList(MimeTypeUtils.ALL));
 	}
 
 	@Override


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/935

Spring Cloud Function now checks if a converter supports the mime type before
calling it. Previously, the converter supported no mime types, so it was never
called, breaking Kafka Tombstone record processing (outbound).

The converter must support all mime types so it can perform a no-op conversion,
retaining the `KafkaNull`.

The abstract converter will return null whenever the payload is not a `KafkaNull`,
which is a signal to spring-cloud-function to try the next converter.