### PR TITLE
fix health indicator to properly indicate partition failure

### DIFF
--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -16,21 +16,10 @@
 
 package org.springframework.cloud.stream.binder.kafka.properties;
 
-import java.time.Duration;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.stream.binder.HeaderMode;
@@ -40,6 +29,15 @@ import org.springframework.expression.Expression;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Configuration properties for the Kafka binder. The properties in this class are
@@ -53,6 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Rafal Zukowski
  * @author Aldo Sinanaj
  * @author Lukasz Kaminski
+ * @author Chukwubuikem Ume-Ugwa
  */
 @ConfigurationProperties(prefix = "spring.cloud.stream.kafka.binder")
 public class KafkaBinderConfigurationProperties {
@@ -89,6 +88,8 @@ public class KafkaBinderConfigurationProperties {
 	private boolean autoCreateTopics = true;
 
 	private boolean autoAddPartitions;
+
+	private boolean considerDownWhenAnyPartitionHasNoLeader;
 
 	private String requiredAcks = "1";
 
@@ -361,6 +362,14 @@ public class KafkaBinderConfigurationProperties {
 
 	public void setAuthorizationExceptionRetryInterval(Duration authorizationExceptionRetryInterval) {
 		this.authorizationExceptionRetryInterval = authorizationExceptionRetryInterval;
+	}
+
+	public boolean isConsiderDownWhenAnyPartitionHasNoLeader() {
+		return considerDownWhenAnyPartitionHasNoLeader;
+	}
+
+	public void setConsiderDownWhenAnyPartitionHasNoLeader(boolean considerDownWhenAnyPartitionHasNoLeader) {
+		this.considerDownWhenAnyPartitionHasNoLeader = considerDownWhenAnyPartitionHasNoLeader;
 	}
 
 	/**

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -16,6 +16,14 @@
 
 package org.springframework.cloud.stream.binder.kafka;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
@@ -28,15 +36,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.PartitionInfo;
-
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
-
 /**
  * Health indicator for Kafka.
  *
@@ -47,6 +46,7 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
  * @author Laur Aliste
  * @author Soby Chacko
  * @author Vladislav Fefelov
+ * @author Chukwubuikem Ume-Ugwa
  */
 public class KafkaBinderHealthIndicator implements HealthIndicator, DisposableBean {
 
@@ -63,6 +63,8 @@ public class KafkaBinderHealthIndicator implements HealthIndicator, DisposableBe
 
 	private Consumer<?, ?> metadataConsumer;
 
+	private boolean considerDownWhenAnyPartitionHasNoLeader;
+
 	public KafkaBinderHealthIndicator(KafkaMessageChannelBinder binder,
 			ConsumerFactory<?, ?> consumerFactory) {
 		this.binder = binder;
@@ -75,6 +77,10 @@ public class KafkaBinderHealthIndicator implements HealthIndicator, DisposableBe
 	 */
 	public void setTimeout(int timeout) {
 		this.timeout = timeout;
+	}
+
+	public void setConsiderDownWhenAnyPartitionHasNoLeader(boolean considerDownWhenAnyPartitionHasNoLeader) {
+		this.considerDownWhenAnyPartitionHasNoLeader = considerDownWhenAnyPartitionHasNoLeader;
 	}
 
 	@Override
@@ -99,55 +105,56 @@ public class KafkaBinderHealthIndicator implements HealthIndicator, DisposableBe
 		}
 	}
 
-	private synchronized  Consumer<?, ?> initMetadataConsumer() {
+	private void initMetadataConsumer() {
 		if (this.metadataConsumer == null) {
 			this.metadataConsumer = this.consumerFactory.createConsumer();
 		}
-		return this.metadataConsumer;
 	}
 
 	private Health buildHealthStatus() {
 		try {
 			initMetadataConsumer();
-			synchronized (this.metadataConsumer) {
-				Set<String> downMessages = new HashSet<>();
-				final Map<String, KafkaMessageChannelBinder.TopicInformation> topicsInUse = KafkaBinderHealthIndicator.this.binder
-						.getTopicsInUse();
-				if (topicsInUse.isEmpty()) {
-					try {
-						this.metadataConsumer.listTopics(Duration.ofSeconds(this.timeout));
-					}
-					catch (Exception e) {
-						return Health.down().withDetail("No topic information available",
-								"Kafka broker is not reachable").build();
-					}
-					return Health.unknown().withDetail("No bindings found",
-							"Kafka binder may not be bound to destinations on the broker").build();
+			Set<String> downMessages = new HashSet<>();
+			final Map<String, KafkaMessageChannelBinder.TopicInformation> topicsInUse = KafkaBinderHealthIndicator.this.binder
+					.getTopicsInUse();
+			if (topicsInUse.isEmpty()) {
+				try {
+					this.metadataConsumer.listTopics(Duration.ofSeconds(this.timeout));
 				}
-				else {
-					for (String topic : topicsInUse.keySet()) {
-						KafkaMessageChannelBinder.TopicInformation topicInformation = topicsInUse
-								.get(topic);
-						if (!topicInformation.isTopicPattern()) {
-							List<PartitionInfo> partitionInfos = this.metadataConsumer
-									.partitionsFor(topic);
-							for (PartitionInfo partitionInfo : partitionInfos) {
-								if (partitionInfo.leader() == null || partitionInfo.leader().id() == -1) {
-									downMessages.add(partitionInfo.toString());
-								}
+				catch (Exception e) {
+					return Health.down().withDetail("No topic information available",
+							"Kafka broker is not reachable").build();
+				}
+				return Health.unknown().withDetail("No bindings found",
+						"Kafka binder may not be bound to destinations on the broker").build();
+			}
+			else {
+				for (String topic : topicsInUse.keySet()) {
+					KafkaMessageChannelBinder.TopicInformation topicInformation = topicsInUse
+							.get(topic);
+					if (!topicInformation.isTopicPattern()) {
+						List<PartitionInfo> partitionInfos = this.metadataConsumer
+								.partitionsFor(topic);
+						for (PartitionInfo partitionInfo : partitionInfos) {
+							if (topicInformation.getPartitionInfos()
+									.contains(partitionInfo)
+									&& partitionInfo.leader() == null) {
+								downMessages.add(partitionInfo.toString());
+							}else if(considerDownWhenAnyPartitionHasNoLeader && partitionInfo.leader() == null){
+								downMessages.add(partitionInfo.toString());
 							}
 						}
 					}
 				}
-				if (downMessages.isEmpty()) {
-					return Health.up().build();
-				}
-				else {
-					return Health.down()
-							.withDetail("Following partitions in use have no leaders: ",
-									downMessages.toString())
-							.build();
-				}
+			}
+			if (downMessages.isEmpty()) {
+				return Health.up().build();
+			}
+			else {
+				return Health.down()
+						.withDetail("Following partitions in use have no leaders: ",
+								downMessages.toString())
+						.build();
 			}
 		}
 		catch (Exception ex) {

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -132,9 +132,7 @@ public class KafkaBinderHealthIndicator implements HealthIndicator, DisposableBe
 							List<PartitionInfo> partitionInfos = this.metadataConsumer
 									.partitionsFor(topic);
 							for (PartitionInfo partitionInfo : partitionInfos) {
-								if (topicInformation.getPartitionInfos()
-										.contains(partitionInfo)
-										&& partitionInfo.leader().id() == -1) {
+								if (partitionInfo.leader() == null || partitionInfo.leader().id() == -1) {
 									downMessages.add(partitionInfo.toString());
 								}
 							}

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderHealthIndicatorConfiguration.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderHealthIndicatorConfiguration.java
@@ -16,12 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.config;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.stream.binder.kafka.KafkaBinderHealthIndicator;
@@ -33,10 +29,14 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.util.ObjectUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Configuration class for Kafka binder health indicator beans.
  *
  * @author Oleg Zhurakousky
+ * @author Chukwubuikem Ume-Ugwa
  */
 
 @Configuration
@@ -66,6 +66,7 @@ class KafkaBinderHealthIndicatorConfiguration {
 		KafkaBinderHealthIndicator indicator = new KafkaBinderHealthIndicator(
 				kafkaMessageChannelBinder, consumerFactory);
 		indicator.setTimeout(configurationProperties.getHealthTimeout());
+		indicator.setConsiderDownWhenAnyPartitionHasNoLeader(configurationProperties.isConsiderDownWhenAnyPartitionHasNoLeader());
 		return indicator;
 	}
 


### PR DESCRIPTION
topicInformation#partitionInfos never actually contains the partitionInfo retrieved from the brokers therefore the original code will only return health down when all brokers are down and the request times out. With this update, health down will be returned if any of the partitions do not have a leader.