### PR TITLE
Remove unnecessary configs from binder

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -492,8 +492,6 @@ public class KafkaMessageChannelBinder extends
 			String transactionIdPrefix,
 			ExtendedProducerProperties<KafkaProducerProperties> producerProperties, String beanName) {
 		Map<String, Object> props = new HashMap<>();
-		props.put(ProducerConfig.RETRIES_CONFIG, 0);
-		props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
 		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
 		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
 				ByteArraySerializer.class);


### PR DESCRIPTION
Following two properties are removed from the producer configs in the binder.

(ProducerConfig.RETRIES_CONFIG, 0)
(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432)

In the case of RETRIES, this is a bug to override the default in Kafka client (MAX_INT) and
in the latter case, this is unnecessary as this is the same default in the client.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/952