### PR TITLE
Change default replication factor to -1

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -106,9 +106,9 @@ spring.cloud.stream.kafka.binder.replicationFactor::
 The replication factor of auto-created topics if `autoCreateTopics` is active.
 Can be overridden on each binding.
 +
-NOTE: If you are using Kafka broker versions prior to 2.4, then this value should be set to `1`.
-Starting with broker version 2.4, the binder will use `-1` as the default value, which indicates the broker to use the same default set on the broker.
-Check with your Kafka broker admins to see if there is a policy in place that requires the replication factor to be greater than 1, in which case, that value should be used instead of any defaults used by the binder.
+NOTE: If you are using Kafka broker versions prior to 2.4, then this value should be set to at least `1`.
+Starting with version 3.0.8, the binder uses `-1` as the default value, which indicates that the broker 'default.replication.factor' property will be used to determine the number of replicas.
+Check with your Kafka broker admins to see if there is a policy in place that requires a minimum replication factor, if that's the case then, typically, the `default.replication.factor` will match that value and `-1` should be used, unless you need a replication factor greater than the minimum.
 +
 Default: `-1`.
 spring.cloud.stream.kafka.binder.autoCreateTopics::

--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -106,7 +106,11 @@ spring.cloud.stream.kafka.binder.replicationFactor::
 The replication factor of auto-created topics if `autoCreateTopics` is active.
 Can be overridden on each binding.
 +
-Default: `1`.
+NOTE: If you are using Kafka broker versions prior to 2.4, then this value should be set to `1`.
+Starting with broker version 2.4, the binder will use `-1` as the default value, which indicates the broker to use the same default set on the broker.
+Check with your Kafka broker admins to see if there is a policy in place that requires the replication factor to be greater than 1, in which case, that value should be used instead of any defaults used by the binder.
++
+Default: `-1`.
 spring.cloud.stream.kafka.binder.autoCreateTopics::
 If set to `true`, the binder creates new topics automatically.
 If set to `false`, the binder relies on the topics being already configured.
@@ -277,7 +281,7 @@ topic.replication-factor::
 The replication factor to use when provisioning topics. Overrides the binder-wide setting.
 Ignored if `replicas-assignments` is present.
 +
-Default: none (the binder-wide default of 1 is used).
+Default: none (the binder-wide default of -1 is used).
 pollTimeout::
 Timeout used for polling in pollable consumers.
 +
@@ -373,7 +377,7 @@ topic.replication-factor::
 The replication factor to use when provisioning topics. Overrides the binder-wide setting.
 Ignored if `replicas-assignments` is present.
 +
-Default: none (the binder-wide default of 1 is used).
+Default: none (the binder-wide default of -1 is used).
 useTopicHeader::
 Set to `true` to override the default binding destination (topic name) with the value of the `KafkaHeaders.TOPIC` message header in the outbound message.
 If the header is not present, the default binding destination is used.

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -92,7 +92,7 @@ public class KafkaBinderConfigurationProperties {
 
 	private String requiredAcks = "1";
 
-	private short replicationFactor = 1;
+	private short replicationFactor = -1;
 
 	private int minPartitionCount = 1;
 


### PR DESCRIPTION
Binder now uses a default value of -1 for replication factor signaling the
broker to use defaults. Users who are on Kafka brokers older than 2.4,
need to set this to the previous default value of 1 used in the binder.

In either case, if there is an admin policy that requires replication factor > 1,
then that value must be used instead.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/808