### PR TITLE
Do not perform alter topics call if no changes required

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -147,6 +147,11 @@ If set to `false`, the binder relies on the partition size of the topic being al
 If the partition count of the target topic is smaller than the expected value, the binder fails to start.
 +
 Default: `false`.
+spring.cloud.stream.kafka.binder.autoAlterTopics::
+If set to `true`, the binder alters destination topic configs if required.
+If set to `false`, the binder relies on existing configs of the topic.
++
+Default: `false`.
 spring.cloud.stream.kafka.binder.transaction.transactionIdPrefix::
 Enables transactions in the binder. See `transaction.id` in the Kafka documentation and https://docs.spring.io/spring-kafka/reference/html/_reference.html#transactions[Transactions] in the `spring-kafka` documentation.
 When transactions are enabled, individual `producer` properties are ignored and all producers use the `spring.cloud.stream.kafka.binder.transaction.producer.*` properties.

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -97,6 +97,8 @@ public class KafkaBinderConfigurationProperties {
 
 	private boolean autoCreateTopics = true;
 
+	private boolean autoAlterTopics;
+
 	private boolean autoAddPartitions;
 
 	private boolean considerDownWhenAnyPartitionHasNoLeader;
@@ -287,6 +289,14 @@ public class KafkaBinderConfigurationProperties {
 
 	public void setAutoCreateTopics(boolean autoCreateTopics) {
 		this.autoCreateTopics = autoCreateTopics;
+	}
+
+	public boolean isAutoAlterTopics() {
+		return autoAlterTopics;
+	}
+
+	public void setAutoAlterTopics(boolean autoAlterTopics) {
+		this.autoAlterTopics = autoAlterTopics;
 	}
 
 	public boolean isAutoAddPartitions() {

--- a/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
+++ b/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/provisioning/KafkaTopicProvisioner.java
@@ -169,7 +169,7 @@ public class KafkaTopicProvisioner implements
 						topicDescriptions.putAll(all.get(this.operationTimeout, TimeUnit.SECONDS));
 					}
 					catch (Exception ex) {
-						throw new ProvisioningException("Problems encountered with partitions finding", ex);
+						throw new ProvisioningException("Problems encountered with partitions finding for: " + name, ex);
 					}
 					return null;
 				});
@@ -242,7 +242,7 @@ public class KafkaTopicProvisioner implements
 					}
 				}
 				catch (Exception ex) {
-					throw new ProvisioningException("provisioning exception", ex);
+					throw new ProvisioningException("Provisioning exception encountered for " + name, ex);
 				}
 			}
 		}
@@ -312,7 +312,7 @@ public class KafkaTopicProvisioner implements
 					throw (Error) throwable;
 				}
 				else {
-					throw new ProvisioningException("provisioning exception", throwable);
+					throw new ProvisioningException("Provisioning exception encountered for " + name, throwable);
 				}
 			}
 			return new KafkaConsumerDestination(name, partitions, dlqTopic);
@@ -336,7 +336,7 @@ public class KafkaTopicProvisioner implements
 			else {
 				// TODO:
 				// https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/pull/514#discussion_r241075940
-				throw new ProvisioningException("Provisioning exception", throwable);
+				throw new ProvisioningException("Provisioning exception encountered for " + name, throwable);
 			}
 		}
 	}
@@ -375,33 +375,8 @@ public class KafkaTopicProvisioner implements
 		Set<String> names = namesFutures.get(this.operationTimeout, TimeUnit.SECONDS);
 		if (names.contains(topicName)) {
 			//check if topic.properties are different from Topic Configuration in Kafka
-			if (this.configurationProperties.isAutoCreateTopics()) {
-				ConfigResource topicConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-				DescribeConfigsResult describeConfigsResult = adminClient
-						.describeConfigs(Collections.singletonList(topicConfigResource));
-				KafkaFuture<Map<ConfigResource, Config>> topicConfigurationFuture = describeConfigsResult.all();
-				Map<ConfigResource, Config> topicConfigMap = topicConfigurationFuture
-						.get(this.operationTimeout, TimeUnit.SECONDS);
-				Config config = topicConfigMap.get(topicConfigResource);
-				final List<AlterConfigOp> updatedConfigEntries = topicProperties.getProperties().entrySet().stream()
-						.filter(propertiesEntry -> {
-							// Property is new and should be added
-							if (config.get(propertiesEntry.getKey()) == null) {
-								return true;
-							}
-							else {
-								// Property changed and should be updated
-								return !config.get(propertiesEntry.getKey()).value().equals(propertiesEntry.getValue());
-							}
-
-						}).map(propertyEntry -> new ConfigEntry(propertyEntry.getKey(), propertyEntry.getValue()))
-						.map(configEntry -> new AlterConfigOp(configEntry, AlterConfigOp.OpType.SET))
-						.collect(Collectors
-								.toList());
-				Map<ConfigResource, Collection<AlterConfigOp>> alterConfigForTopics = new HashMap<>();
-				alterConfigForTopics.put(topicConfigResource, updatedConfigEntries);
-				AlterConfigsResult alterConfigsResult = adminClient.incrementalAlterConfigs(alterConfigForTopics);
-				alterConfigsResult.all().get(this.operationTimeout, TimeUnit.SECONDS);
+			if (this.configurationProperties.isAutoAlterTopics()) {
+				alterTopicConfigsIfNecessary(adminClient, topicName, topicProperties);
 			}
 			// only consider minPartitionCount for resizing if autoAddPartitions is true
 			int effectivePartitionCount = this.configurationProperties
@@ -492,6 +467,43 @@ public class KafkaTopicProvisioner implements
 				}
 				return null;
 			});
+		}
+	}
+
+	private void alterTopicConfigsIfNecessary(AdminClient adminClient,
+											  String topicName,
+											  KafkaTopicProperties topicProperties)
+			throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+		ConfigResource topicConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+		DescribeConfigsResult describeConfigsResult = adminClient
+				.describeConfigs(Collections.singletonList(topicConfigResource));
+		KafkaFuture<Map<ConfigResource, Config>> topicConfigurationFuture = describeConfigsResult.all();
+		Map<ConfigResource, Config> topicConfigMap = topicConfigurationFuture
+				.get(this.operationTimeout, TimeUnit.SECONDS);
+		Config config = topicConfigMap.get(topicConfigResource);
+		final List<AlterConfigOp> updatedConfigEntries = topicProperties.getProperties().entrySet().stream()
+				.filter(propertiesEntry -> {
+					// Property is new and should be added
+					if (config.get(propertiesEntry.getKey()) == null) {
+						return true;
+					}
+					else {
+						// Property changed and should be updated
+						return !config.get(propertiesEntry.getKey()).value().equals(propertiesEntry.getValue());
+					}
+
+				})
+				.map(propertyEntry -> new ConfigEntry(propertyEntry.getKey(), propertyEntry.getValue()))
+				.map(configEntry -> new AlterConfigOp(configEntry, AlterConfigOp.OpType.SET))
+				.collect(Collectors.toList());
+		if(!updatedConfigEntries.isEmpty()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Attempting to alter configs " + updatedConfigEntries + " for the topic:" + topicName);
+			}
+			Map<ConfigResource, Collection<AlterConfigOp>> alterConfigForTopics = new HashMap<>();
+			alterConfigForTopics.put(topicConfigResource, updatedConfigEntries);
+			AlterConfigsResult alterConfigsResult = adminClient.incrementalAlterConfigs(alterConfigForTopics);
+			alterConfigsResult.all().get(this.operationTimeout, TimeUnit.SECONDS);
 		}
 	}
 

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/topic/configs/BaseKafkaBinderTopicPropertiesUpdateTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/topic/configs/BaseKafkaBinderTopicPropertiesUpdateTest.java
@@ -14,33 +14,18 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder.kafka.integration;
+package org.springframework.cloud.stream.binder.kafka.integration.topic.configs;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.DescribeConfigsResult;
-import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.config.ConfigResource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.Output;
 import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
@@ -48,20 +33,20 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * @author Heiko Does
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+@SpringBootTest(
+		classes = BaseKafkaBinderTopicPropertiesUpdateTest.TopicAutoConfigsTestConfig.class,
+		webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
 		"spring.cloud.stream.kafka.bindings.standard-out.producer.topic.properties.retention.ms=9001",
 		"spring.cloud.stream.kafka.default.producer.topic.properties.retention.ms=-1",
 		"spring.cloud.stream.kafka.bindings.standard-in.consumer.topic.properties.retention.ms=9001",
 		"spring.cloud.stream.kafka.default.consumer.topic.properties.retention.ms=-1"
 })
 @DirtiesContext
-public class KafkaBinderTopicPropertiesUpdateTest {
+public abstract class BaseKafkaBinderTopicPropertiesUpdateTest {
 
 	private static final String KAFKA_BROKERS_PROPERTY = "spring.cloud.stream.kafka.binder.brokers";
 
@@ -79,30 +64,9 @@ public class KafkaBinderTopicPropertiesUpdateTest {
 		System.clearProperty(KAFKA_BROKERS_PROPERTY);
 	}
 
-	@Autowired
-	private ConfigurableApplicationContext context;
-
-	@Test
-	public void testKafkaBinderUpdateTopicConfiguration() throws Exception {
-		Map<String, Object> adminClientConfig = new HashMap<>();
-		adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaEmbedded.getEmbeddedKafka().getBrokersAsString());
-		AdminClient adminClient = AdminClient.create(adminClientConfig);
-		ConfigResource standardInConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, "standard-in");
-		ConfigResource standardOutConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, "standard-out");
-		DescribeConfigsResult describeConfigsResult = adminClient.describeConfigs(Arrays
-				.asList(standardInConfigResource, standardOutConfigResource));
-		KafkaFuture<Map<ConfigResource, Config>> kafkaFuture = describeConfigsResult.all();
-		Map<ConfigResource, Config> configResourceConfigMap = kafkaFuture.get(3, TimeUnit.SECONDS);
-		Config standardInTopicConfig = configResourceConfigMap.get(standardInConfigResource);
-		assertThat(standardInTopicConfig.get("retention.ms").value()).isEqualTo("9001");
-
-		Config standardOutTopicConfig = configResourceConfigMap.get(standardOutConfigResource);
-		assertThat(standardOutTopicConfig.get("retention.ms").value()).isEqualTo("9001");
-	}
-
 	@EnableBinding(CustomBindingForTopicPropertiesUpdateTesting.class)
 	@EnableAutoConfiguration
-	public static class KafkaMetricsTestConfig {
+	public static class TopicAutoConfigsTestConfig {
 
 		@StreamListener("standard-in")
 		@SendTo("standard-out")

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/topic/configs/DisabledKafkaBinderTopicPropertiesUpdateTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/topic/configs/DisabledKafkaBinderTopicPropertiesUpdateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.integration.topic.configs;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.ConfigResource;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Taras Danylchuk
+ */
+public class DisabledKafkaBinderTopicPropertiesUpdateTest extends BaseKafkaBinderTopicPropertiesUpdateTest {
+
+	@Test
+	public void testKafkaBinderShouldNotUpdateTopicConfigurationOnDisabledFeature() throws Exception {
+		Map<String, Object> adminClientConfig = new HashMap<>();
+		adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaEmbedded.getEmbeddedKafka().getBrokersAsString());
+		AdminClient adminClient = AdminClient.create(adminClientConfig);
+		ConfigResource standardInConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, "standard-in");
+		ConfigResource standardOutConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, "standard-out");
+		DescribeConfigsResult describeConfigsResult = adminClient.describeConfigs(Arrays
+				.asList(standardInConfigResource, standardOutConfigResource));
+		KafkaFuture<Map<ConfigResource, Config>> kafkaFuture = describeConfigsResult.all();
+		Map<ConfigResource, Config> configResourceConfigMap = kafkaFuture.get(3, TimeUnit.SECONDS);
+		Config standardInTopicConfig = configResourceConfigMap.get(standardInConfigResource);
+		assertThat(standardInTopicConfig.get("retention.ms").value()).isEqualTo("604800000");
+
+		Config standardOutTopicConfig = configResourceConfigMap.get(standardOutConfigResource);
+		assertThat(standardOutTopicConfig.get("retention.ms").value()).isEqualTo("604800000");
+	}
+}

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/topic/configs/KafkaBinderTopicPropertiesUpdateTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/topic/configs/KafkaBinderTopicPropertiesUpdateTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.integration.topic.configs;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.ConfigResource;
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Heiko Does
+ */
+@TestPropertySource(properties = "spring.cloud.stream.kafka.binder.autoAlterTopics=true")
+public class KafkaBinderTopicPropertiesUpdateTest extends BaseKafkaBinderTopicPropertiesUpdateTest {
+
+	@Test
+	public void testKafkaBinderUpdateTopicConfiguration() throws Exception {
+		Map<String, Object> adminClientConfig = new HashMap<>();
+		adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaEmbedded.getEmbeddedKafka().getBrokersAsString());
+		AdminClient adminClient = AdminClient.create(adminClientConfig);
+		ConfigResource standardInConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, "standard-in");
+		ConfigResource standardOutConfigResource = new ConfigResource(ConfigResource.Type.TOPIC, "standard-out");
+		DescribeConfigsResult describeConfigsResult = adminClient.describeConfigs(Arrays
+				.asList(standardInConfigResource, standardOutConfigResource));
+		KafkaFuture<Map<ConfigResource, Config>> kafkaFuture = describeConfigsResult.all();
+		Map<ConfigResource, Config> configResourceConfigMap = kafkaFuture.get(3, TimeUnit.SECONDS);
+		Config standardInTopicConfig = configResourceConfigMap.get(standardInConfigResource);
+		assertThat(standardInTopicConfig.get("retention.ms").value()).isEqualTo("9001");
+
+		Config standardOutTopicConfig = configResourceConfigMap.get(standardOutConfigResource);
+		assertThat(standardOutTopicConfig.get("retention.ms").value()).isEqualTo("9001");
+	}
+}


### PR DESCRIPTION
There are a few purposes of this change request:
- omit the redundant call to the broker on application startup (decrease startup time)
- do not fail startup if the broker does not support INCREMENTAL_ALTER_CONFIGS
- remove a bit exception logs

So Recently I've tried to bump the cloud version to the latest and failed on deploying my app.
In tests I have broker with all features enabled whereas on dev environment I have features like INCREMENTAL_ALTER_CONFIGS disabled.

Application yet successfully started but stream never went up due to 
```
org.springframework.cloud.stream.provisioning.ProvisioningException: Provisioning exception; nested exception is java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.UnsupportedVersionException: The broker does not support INCREMENTAL_ALTER_CONFIGS 	at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.createTopic(KafkaTopicProvisioner.java:339) 	at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.doProvisionConsumerDestination(KafkaTopicProvisioner.java:224) 	at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.provisionConsumerDestination(KafkaTopicProvisioner.java:190) 	at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.provisionConsumerDestination(KafkaTopicProvisioner.java:86) 	at org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.doBindConsumer(AbstractMessageChannelBinder.java:403) 	at org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.doBindConsumer(AbstractMessageChannelBinder.java:91) 	at org.springframework.cloud.stream.binder.AbstractBinder.bindConsumer(AbstractBinder.java:143) 	at org.springframework.cloud.stream.binding.BindingService.lambda$rescheduleConsumerBinding$1(BindingService.java:201) 	at org.springframework.cloud.sleuth.instrument.async.TraceRunnable.run(TraceRunnable.java:68) 	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) 	at java.base/java.lang.Thread.run(Thread.java:834) Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.UnsupportedVersionException: The broker does not support INCREMENTAL_ALTER_CONFIGS 	at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45) 	at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32) 	at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:104) 	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:272) 	at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.createTopicAndPartitions(KafkaTopicProvisioner.java:404) 	at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.createTopicIfNecessary(KafkaTopicProvisioner.java:349) 	at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.createTopic(KafkaTopicProvisioner.java:326) 	... 15 more Caused by: org.apache.kafka.common.errors.UnsupportedVersionException: The broker does not support INCREMENTAL_ALTER_CONFIGS
--
```

From this exception is not clear which bonder is actually causing an issue, so only debugging help.

Also, I have a question from this case: isn't healthcheck for binder supposed to be DOWN is this case?