### PR TITLE
KafkaBinderMetrics NoopGauge/filtering changes

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
@@ -106,7 +106,7 @@ public class KafkaBinderMetricsTest {
 
 	@Test
 	public void shouldNotContainAnyMetricsWhenUsingNoopGauge() {
-		// Adding NoopGague for the offset metric.
+		// Adding NoopGauge for the offset metric.
 		meterRegistry.config().meterFilter(
 				MeterFilter.denyNameStartsWith("spring.cloud.stream.binder.kafka.offset"));
 
@@ -121,7 +121,7 @@ public class KafkaBinderMetricsTest {
 				.willReturn(partitions);
 		metrics.bindTo(meterRegistry);
 
-		// Because of the NoopGause, the meterRegistry should contain no metric.
+		// Because of the NoopGauge, the meterRegistry should contain no metric.
 		assertThat(meterRegistry.getMeters()).hasSize(0);
 	}
 

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
@@ -74,7 +74,7 @@ public class KafkaBinderMetricsTest {
 
 	@Before
 	public void setup() {
-		MockitoAnnotations.initMocks(this);
+		MockitoAnnotations.openMocks(this);
 		org.mockito.BDDMockito.given(consumerFactory
 				.createConsumer(ArgumentMatchers.any(), ArgumentMatchers.any()))
 				.willReturn(consumer);
@@ -123,9 +123,6 @@ public class KafkaBinderMetricsTest {
 
 		// Because of the NoopGause, the meterRegistry should contain no metric.
 		assertThat(meterRegistry.getMeters()).hasSize(0);
-
-		// Reset the MeterRegistry to accept all metrics.
-		meterRegistry.config().meterFilter(MeterFilter.accept());
 	}
 
 	@Test

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -101,6 +102,30 @@ public class KafkaBinderMetricsTest {
 		assertThat(meterRegistry.get(KafkaBinderMetrics.METRIC_NAME)
 				.tag("group", "group1-metrics").tag("topic", TEST_TOPIC).gauge().value())
 						.isEqualTo(500.0);
+	}
+
+	@Test
+	public void shouldNotContainAnyMetricsWhenUsingNoopGauge() {
+		// Adding NoopGague for the offset metric.
+		meterRegistry.config().meterFilter(
+				MeterFilter.denyNameStartsWith("spring.cloud.stream.binder.kafka.offset"));
+
+		// Because we have NoopGauge for the offset metric  in the meter registry, none of these expectations matter.
+		org.mockito.BDDMockito
+				.given(consumer.committed(ArgumentMatchers.any(TopicPartition.class)))
+				.willReturn(new OffsetAndMetadata(500));
+		List<PartitionInfo> partitions = partitions(new Node(0, null, 0));
+		topicsInUse.put(TEST_TOPIC,
+				new TopicInformation("group1-metrics", partitions, false));
+		org.mockito.BDDMockito.given(consumer.partitionsFor(TEST_TOPIC))
+				.willReturn(partitions);
+		metrics.bindTo(meterRegistry);
+
+		// Because of the NoopGause, the meterRegistry should contain no metric.
+		assertThat(meterRegistry.getMeters()).hasSize(0);
+
+		// Reset the MeterRegistry to accept all metrics.
+		meterRegistry.config().meterFilter(MeterFilter.accept());
 	}
 
 	@Test


### PR DESCRIPTION
Fixing the problem of KafkBinderMetrics scheduled task
for finding the offset lag gets triggered, even when the
guage is registered as a NoopGague in the MeterRegistry.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/995