### PR TITLE
Removed letter j from exception message

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/InteractiveQueryService.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/InteractiveQueryService.java
@@ -109,7 +109,7 @@ public class InteractiveQueryService {
 			if (store != null) {
 				return store;
 			}
-			throw new IllegalStateException("Error when retrieving state store: j " + storeName, throwable);
+			throw new IllegalStateException("Error when retrieving state store: " + storeName, throwable);
 		});
 	}
 


### PR DESCRIPTION
Not sure but it seems like typo. 
throw new IllegalStateException("Error when retrieving state store: j " + storeName, throwable);