### PR TITLE
Support KStream lifecycle through binding endpoint

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1692,9 +1692,9 @@ public class KafkaStreamsApplication {
 
 As we can see, the application has two Kafka Streams functions - one, a consumer and another a function.
 The consumer binding is named by default as `consumer-in-0`.
-Similarly, for the function, the input binding is `function-in-0` and `function-out-0`.
+Similarly, for the function, the input binding is `function-in-0` and the output binding is `function-out-0`.
 
-Once the application started, we can find details about the bindings using the following bindings endpoint.
+Once the application is started, we can find details about the bindings using the following bindings endpoint.
 
 ```
  curl http://localhost:8080/actuator/bindings | jq .

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1640,6 +1640,118 @@ For instance, if we want to change the header key on this binding to `my_event` 
 
 `spring.cloud.stream.kafka.streams.bindings.process-in-0.consumer.eventTypeHeaderKey=my_event`.
 
+=== Binding visualization and control in Kafka Streams binder
+
+Starting with version 3.1.2, Kafka Streams binder supports binding visualization and control.
+The only two lifecycle phases supported are `STOPPED` and `STARTED`.
+The lifecycle phases `PAUSED` and `RESUMED` are not available in Kafka Streams binder.
+
+In order to activate binding visualization and control, the application needs to include the following two dependencies.
+
+```
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+<dependency>
+     <groupId>org.springframework.boot</groupId>
+     <artifactId>spring-boot-starter-web</artifactId>
+</dependency>
+```
+
+If you prefer using webflux, you can then include `spring-boot-starter-webflux` instead of the standard web dependency.
+
+In addition, you also need to set the following property:
+
+```
+management.endpoints.web.exposure.include=bindings
+```
+
+To illustrate this feature further, let us use the following application as a guide:
+
+```
+@SpringBootApplication
+public class KafkaStreamsApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(KafkaStreamsApplication.class, args);
+	}
+
+	@Bean
+	public Consumer<KStream<String, String>> consumer() {
+		return s -> s.foreach((key, value) -> System.out.println(value));
+	}
+
+	@Bean
+	public Function<KStream<String, String>, KStream<String, String>> function() {
+		return ks -> ks;
+	}
+
+}
+```
+
+As we can see, the application has two Kafka Streams functions - one, a consumer and another a function.
+The consumer binding is named by default as `consumer-in-0`.
+Similarly, for the function, the input binding is `function-in-0` and `function-out-0`.
+
+Once the application started, we can find details about the bindings using the following bindings endpoint.
+
+```
+ curl http://localhost:8080/actuator/bindings | jq .
+[
+  {
+    "bindingName": "consumer-in-0",
+    "name": "consumer-in-0",
+    "group": "consumer-applicationId",
+    "pausable": false,
+    "state": "running",
+    "paused": false,
+    "input": true,
+    "extendedInfo": {}
+  },
+  {
+    "bindingName": "function-in-0",
+    "name": "function-in-0",
+    "group": "function-applicationId",
+    "pausable": false,
+    "state": "running",
+    "paused": false,
+    "input": true,
+    "extendedInfo": {}
+  },
+  {
+    "bindingName": "function-out-0",
+    "name": "function-out-0",
+    "group": "function-applicationId",
+    "pausable": false,
+    "state": "running",
+    "paused": false,
+    "input": false,
+    "extendedInfo": {}
+  }
+]
+```
+
+The details about all three bindings can be found above.
+
+Let us now stop the consumer-in-0 binding.
+
+```
+curl -d '{"state":"STOPPED"}' -H "Content-Type: application/json" -X POST http://localhost:8080/actuator/bindings/consumer-in-0
+```
+
+At this point, no records will be received through this binding.
+
+Start the binding again.
+
+```
+curl -d '{"state":"STARTED"}' -H "Content-Type: application/json" -X POST http://localhost:8080/actuator/bindings/consumer-in-0
+```
+
+When there are multiple bindings present on a single function, invoking these operations on any of those bindings will work.
+This is because all the bindings on a single function are backed by the same `StreamsBuilderFactoryBean`.
+Therefore, for the function above, either `function-in-0` or `function-out-0` will work.
+
 === Configuration Options
 
 This section contains the configuration options used by the Kafka Streams binder.

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
@@ -160,7 +160,7 @@ public abstract class AbstractKafkaStreamsBinderProcessor implements Application
 					(KTableBoundElementFactory.KTableWrapper) targetBean;
 			//wrap the proxy created during the initial target type binding with real object (KTable)
 			kTableWrapper.wrap((KTable<Object, Object>) table);
-			this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactory(streamsBuilderFactoryBean);
+			this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactoryPerBinding(input, streamsBuilderFactoryBean);
 			arguments[index] = table;
 		}
 		else if (parameterType.isAssignableFrom(GlobalKTable.class)) {
@@ -172,7 +172,7 @@ public abstract class AbstractKafkaStreamsBinderProcessor implements Application
 					(GlobalKTableBoundElementFactory.GlobalKTableWrapper) targetBean;
 			//wrap the proxy created during the initial target type binding with real object (KTable)
 			globalKTableWrapper.wrap((GlobalKTable<Object, Object>) table);
-			this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactory(streamsBuilderFactoryBean);
+			this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactoryPerBinding(input, streamsBuilderFactoryBean);
 			arguments[index] = table;
 		}
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
@@ -103,9 +103,6 @@ public class GlobalKTableBinder extends
 			@Override
 			public synchronized void stop() {
 				super.stop();
-
-				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
-						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
 				KafkaStreamsBinderUtils.closeDlqProducerFactories(kafkaStreamsBindingInformationCatalogue, streamsBuilderFactoryBean);
 			}
 		};

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.List;
+
 import org.apache.kafka.streams.kstream.GlobalKTable;
 
 import org.springframework.cloud.stream.binder.AbstractBinder;
@@ -31,6 +33,7 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsProducerProperties;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
@@ -79,16 +82,33 @@ public class GlobalKTableBinder extends
 			group = properties.getExtension().getApplicationId();
 		}
 		final RetryTemplate retryTemplate = buildRetryTemplate(properties);
-		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group,
-				getApplicationContext(), this.kafkaTopicProvisioner,
-				this.binderConfigurationProperties, properties, retryTemplate, getBeanFactory(),
-				this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget),
-				this.kafkaStreamsBindingInformationCatalogue);
 
 		final String bindingName = this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget);
 		final StreamsBuilderFactoryBean streamsBuilderFactoryBean = this.kafkaStreamsBindingInformationCatalogue
 				.getStreamsBuilderFactoryBeanPerBinding().get(bindingName);
-		return new DefaultBinding<>(bindingName, group, inputTarget, streamsBuilderFactoryBean);
+
+		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group,
+				getApplicationContext(), this.kafkaTopicProvisioner,
+				this.binderConfigurationProperties, properties, retryTemplate, getBeanFactory(),
+				this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget),
+				this.kafkaStreamsBindingInformationCatalogue, streamsBuilderFactoryBean);
+
+		return new DefaultBinding<GlobalKTable<Object, Object>>(bindingName, group, inputTarget, streamsBuilderFactoryBean) {
+
+			@Override
+			public boolean isInput() {
+				return true;
+			}
+
+			@Override
+			public synchronized void stop() {
+				super.stop();
+
+				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
+						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
+				KafkaStreamsBinderUtils.closeDlqProducerFactories(streamsBuilderFactoryBean, dlqProducerFactories);
+			}
+		};
 	}
 
 	@Override

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsProducerProperties;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
@@ -84,7 +85,10 @@ public class GlobalKTableBinder extends
 				this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget),
 				this.kafkaStreamsBindingInformationCatalogue);
 
-		return new DefaultBinding<>(name, group, inputTarget, null);
+		final String bindingName = this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget);
+		final StreamsBuilderFactoryBean streamsBuilderFactoryBean = this.kafkaStreamsBindingInformationCatalogue
+				.getStreamsBuilderFactoryBeanPerBinding().get(bindingName);
+		return new DefaultBinding<>(bindingName, group, inputTarget, streamsBuilderFactoryBean);
 	}
 
 	@Override

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/GlobalKTableBinder.java
@@ -106,7 +106,7 @@ public class GlobalKTableBinder extends
 
 				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
 						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
-				KafkaStreamsBinderUtils.closeDlqProducerFactories(streamsBuilderFactoryBean, dlqProducerFactories);
+				KafkaStreamsBinderUtils.closeDlqProducerFactories(kafkaStreamsBindingInformationCatalogue, streamsBuilderFactoryBean);
 			}
 		};
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.logging.Log;
@@ -41,6 +42,7 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsProducerProperties;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
@@ -106,15 +108,16 @@ class KStreamBinder extends
 
 		final RetryTemplate retryTemplate = buildRetryTemplate(properties);
 
+		final String bindingName = this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget);
+		final StreamsBuilderFactoryBean streamsBuilderFactoryBean = this.kafkaStreamsBindingInformationCatalogue
+				.getStreamsBuilderFactoryBeanPerBinding().get(bindingName);
+
 		KafkaStreamsBinderUtils.prepareConsumerBinding(name, group,
 				getApplicationContext(), this.kafkaTopicProvisioner,
 				this.binderConfigurationProperties, properties, retryTemplate, getBeanFactory(),
 				this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget),
-				this.kafkaStreamsBindingInformationCatalogue);
+				this.kafkaStreamsBindingInformationCatalogue, streamsBuilderFactoryBean);
 
-		final String bindingName = this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget);
-		final StreamsBuilderFactoryBean streamsBuilderFactoryBean = this.kafkaStreamsBindingInformationCatalogue
-				.getStreamsBuilderFactoryBeanPerBinding().get(bindingName);
 
 		return new DefaultBinding<KStream<Object, Object>>(bindingName, group,
 				inputTarget, streamsBuilderFactoryBean) {
@@ -122,6 +125,15 @@ class KStreamBinder extends
 			@Override
 			public boolean isInput() {
 				return true;
+			}
+
+			@Override
+			public synchronized void stop() {
+				super.stop();
+
+				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
+						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
+				KafkaStreamsBinderUtils.closeDlqProducerFactories(streamsBuilderFactoryBean, dlqProducerFactories);
 			}
 		};
 	}
@@ -169,6 +181,15 @@ class KStreamBinder extends
 			@Override
 			public boolean isInput() {
 				return false;
+			}
+
+			@Override
+			public synchronized void stop() {
+				super.stop();
+
+				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
+						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
+				KafkaStreamsBinderUtils.closeDlqProducerFactories(streamsBuilderFactoryBean, dlqProducerFactories);
 			}
 		};
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.util.Properties;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.common.serialization.Serde;
@@ -38,6 +40,7 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsProducerProperties;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
@@ -76,10 +79,10 @@ class KStreamBinder extends
 	private final KeyValueSerdeResolver keyValueSerdeResolver;
 
 	KStreamBinder(KafkaStreamsBinderConfigurationProperties binderConfigurationProperties,
-			KafkaTopicProvisioner kafkaTopicProvisioner,
-			KafkaStreamsMessageConversionDelegate kafkaStreamsMessageConversionDelegate,
-			KafkaStreamsBindingInformationCatalogue KafkaStreamsBindingInformationCatalogue,
-			KeyValueSerdeResolver keyValueSerdeResolver) {
+				KafkaTopicProvisioner kafkaTopicProvisioner,
+				KafkaStreamsMessageConversionDelegate kafkaStreamsMessageConversionDelegate,
+				KafkaStreamsBindingInformationCatalogue KafkaStreamsBindingInformationCatalogue,
+				KeyValueSerdeResolver keyValueSerdeResolver) {
 		this.binderConfigurationProperties = binderConfigurationProperties;
 		this.kafkaTopicProvisioner = kafkaTopicProvisioner;
 		this.kafkaStreamsMessageConversionDelegate = kafkaStreamsMessageConversionDelegate;
@@ -109,7 +112,18 @@ class KStreamBinder extends
 				this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget),
 				this.kafkaStreamsBindingInformationCatalogue);
 
-		return new DefaultBinding<>(name, group, inputTarget, null);
+		final String bindingName = this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget);
+		final StreamsBuilderFactoryBean streamsBuilderFactoryBean = this.kafkaStreamsBindingInformationCatalogue
+				.getStreamsBuilderFactoryBeanPerBinding().get(bindingName);
+
+		return new DefaultBinding<KStream<Object, Object>>(bindingName, group,
+				inputTarget, streamsBuilderFactoryBean) {
+
+			@Override
+			public boolean isInput() {
+				return true;
+			}
+		};
 	}
 
 	@Override
@@ -138,7 +152,25 @@ class KStreamBinder extends
 
 		to(properties.isUseNativeEncoding(), name, outboundBindTarget,
 				(Serde<Object>) keySerde, (Serde<Object>) valueSerde, properties.getExtension());
-		return new DefaultBinding<>(name, null, outboundBindTarget, null);
+
+		final String bindingName = this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(outboundBindTarget);
+		final StreamsBuilderFactoryBean streamsBuilderFactoryBean = this.kafkaStreamsBindingInformationCatalogue
+				.getStreamsBuilderFactoryBeanPerBinding().get(bindingName);
+
+		// We need the application id to pass to DefaultBinding so that it won't be interpreted as an anonymous group.
+		// In case, if we can't find application.id (which is unlikely), we just default to bindingName.
+		// This will only be used for lifecycle management through actuator endpoints.
+		final Properties streamsConfiguration = streamsBuilderFactoryBean.getStreamsConfiguration();
+		final String applicationId = streamsConfiguration != null ? (String) streamsConfiguration.get("application.id") : bindingName;
+
+		return new DefaultBinding<KStream<Object, Object>>(bindingName,
+				applicationId, outboundBindTarget, streamsBuilderFactoryBean) {
+
+			@Override
+			public boolean isInput() {
+				return false;
+			}
+		};
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KStreamBinder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
-import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.logging.Log;
@@ -42,7 +41,6 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsProducerProperties;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
-import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
@@ -130,10 +128,7 @@ class KStreamBinder extends
 			@Override
 			public synchronized void stop() {
 				super.stop();
-
-				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
-						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
-				KafkaStreamsBinderUtils.closeDlqProducerFactories(streamsBuilderFactoryBean, dlqProducerFactories);
+				KafkaStreamsBinderUtils.closeDlqProducerFactories(kafkaStreamsBindingInformationCatalogue, streamsBuilderFactoryBean);
 			}
 		};
 	}
@@ -186,10 +181,7 @@ class KStreamBinder extends
 			@Override
 			public synchronized void stop() {
 				super.stop();
-
-				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
-						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
-				KafkaStreamsBinderUtils.closeDlqProducerFactories(streamsBuilderFactoryBean, dlqProducerFactories);
+				KafkaStreamsBinderUtils.closeDlqProducerFactories(kafkaStreamsBindingInformationCatalogue, streamsBuilderFactoryBean);
 			}
 		};
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinder.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
-import java.util.List;
-
 import org.apache.kafka.streams.kstream.KTable;
 
 import org.springframework.cloud.stream.binder.AbstractBinder;
@@ -33,7 +31,6 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsProducerProperties;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
-import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
@@ -106,10 +103,7 @@ class KTableBinder extends
 			@Override
 			public synchronized void stop() {
 				super.stop();
-
-				final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
-						kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
-				KafkaStreamsBinderUtils.closeDlqProducerFactories(streamsBuilderFactoryBean, dlqProducerFactories);
+				KafkaStreamsBinderUtils.closeDlqProducerFactories(kafkaStreamsBindingInformationCatalogue, streamsBuilderFactoryBean);
 			}
 		};
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinder.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KTableBinder.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStr
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsConsumerProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kafka.streams.properties.KafkaStreamsProducerProperties;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 
@@ -87,7 +88,10 @@ class KTableBinder extends
 				this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget),
 				this.kafkaStreamsBindingInformationCatalogue);
 
-		return new DefaultBinding<>(name, group, inputTarget, null);
+		final String bindingName = this.kafkaStreamsBindingInformationCatalogue.bindingNamePerTarget(inputTarget);
+		final StreamsBuilderFactoryBean streamsBuilderFactoryBean = this.kafkaStreamsBindingInformationCatalogue
+				.getStreamsBuilderFactoryBeanPerBinding().get(bindingName);
+		return new DefaultBinding<>(bindingName, group, inputTarget, streamsBuilderFactoryBean);
 	}
 
 	@Override

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderMetrics.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderMetrics.java
@@ -92,11 +92,13 @@ public class KafkaStreamsBinderMetrics {
 			this.meterBinder = registry -> {
 				if (streamsBuilderFactoryBeans != null) {
 					for (StreamsBuilderFactoryBean streamsBuilderFactoryBean : streamsBuilderFactoryBeans) {
-						KafkaStreams kafkaStreams = streamsBuilderFactoryBean.getKafkaStreams();
-						final Map<MetricName, ? extends Metric> metrics = kafkaStreams.metrics();
+						if (streamsBuilderFactoryBean.isRunning()) {
+							KafkaStreams kafkaStreams = streamsBuilderFactoryBean.getKafkaStreams();
+							final Map<MetricName, ? extends Metric> metrics = kafkaStreams.metrics();
 
-						prepareToBindMetrics(registry, metrics);
-						checkAndBindMetrics(registry, metrics);
+							prepareToBindMetrics(registry, metrics);
+							checkAndBindMetrics(registry, metrics);
+						}
 					}
 				}
 			};

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.stream.binder.kafka.streams;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -28,6 +29,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.streams.kstream.KStream;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -44,6 +46,7 @@ import org.springframework.cloud.stream.binder.kafka.utils.DlqDestinationResolve
 import org.springframework.cloud.stream.binder.kafka.utils.DlqPartitionFunction;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.MethodParameter;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -51,6 +54,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -74,7 +78,8 @@ final class KafkaStreamsBinderUtils {
 									ExtendedConsumerProperties<KafkaStreamsConsumerProperties> properties,
 									RetryTemplate retryTemplate,
 									ConfigurableListableBeanFactory beanFactory, String bindingName,
-									KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue) {
+									KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue,
+									StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
 
 		ExtendedConsumerProperties<KafkaConsumerProperties> extendedConsumerProperties =
 				(ExtendedConsumerProperties) properties;
@@ -110,7 +115,7 @@ final class KafkaStreamsBinderUtils {
 					new ExtendedProducerProperties<>(
 							extendedConsumerProperties.getExtension().getDlqProducerProperties()),
 					binderConfigurationProperties);
-			kafkaStreamsBindingInformationCatalogue.addDlqProducerFactory(producerFactory);
+			kafkaStreamsBindingInformationCatalogue.addDlqProducerFactory(streamsBuilderFactoryBean, producerFactory);
 
 			KafkaOperations<byte[], byte[]> kafkaTemplate = new KafkaTemplate<>(producerFactory);
 
@@ -201,4 +206,19 @@ final class KafkaStreamsBinderUtils {
 		return KStream.class.isAssignableFrom(targetBeanClass)
 				&& KStream.class.isAssignableFrom(methodParameter.getParameterType());
 	}
+
+	static void closeDlqProducerFactories(StreamsBuilderFactoryBean streamsBuilderFactoryBean,
+												List<ProducerFactory<byte[], byte[]>> dlqProducerFactories) {
+		if (!CollectionUtils.isEmpty(dlqProducerFactories)) {
+			for (ProducerFactory<byte[], byte[]> producerFactory : dlqProducerFactories) {
+				try {
+					((DisposableBean) producerFactory).destroy();
+				}
+				catch (Exception exception) {
+					throw new IllegalStateException(exception);
+				}
+			}
+		}
+	}
+
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
@@ -207,8 +207,12 @@ final class KafkaStreamsBinderUtils {
 				&& KStream.class.isAssignableFrom(methodParameter.getParameterType());
 	}
 
-	static void closeDlqProducerFactories(StreamsBuilderFactoryBean streamsBuilderFactoryBean,
-												List<ProducerFactory<byte[], byte[]>> dlqProducerFactories) {
+	static void closeDlqProducerFactories(KafkaStreamsBindingInformationCatalogue kafkaStreamsBindingInformationCatalogue,
+										StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
+
+		final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories =
+				kafkaStreamsBindingInformationCatalogue.getDlqProducerFactory(streamsBuilderFactoryBean);
+
 		if (!CollectionUtils.isEmpty(dlqProducerFactories)) {
 			for (ProducerFactory<byte[], byte[]> producerFactory : dlqProducerFactories) {
 				try {

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsConfig;
@@ -34,6 +35,7 @@ import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.core.ResolvableType;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.util.CollectionUtils;
 
 /**
  * A catalogue that provides binding information for Kafka Streams target types such as
@@ -58,7 +60,7 @@ public class KafkaStreamsBindingInformationCatalogue {
 
 	private final Map<Object, String> bindingNamesPerTarget = new HashMap<>();
 
-	private final List<ProducerFactory<byte[], byte[]>> dlqProducerFactories = new ArrayList<>();
+	private final Map<StreamsBuilderFactoryBean, List<ProducerFactory<byte[], byte[]>>> dlqProducerFactories = new HashMap<>();
 
 	/**
 	 * For a given bounded {@link KStream}, retrieve it's corresponding destination on the
@@ -182,10 +184,23 @@ public class KafkaStreamsBindingInformationCatalogue {
 	}
 
 	public List<ProducerFactory<byte[], byte[]>> getDlqProducerFactories() {
-		return this.dlqProducerFactories;
+		return this.dlqProducerFactories.values()
+				.stream()
+				.flatMap(List::stream)
+				.collect(Collectors.toList());
 	}
 
-	public void addDlqProducerFactory(ProducerFactory<byte[], byte[]> producerFactory) {
-		this.dlqProducerFactories.add(producerFactory);
+	public List<ProducerFactory<byte[], byte[]>> getDlqProducerFactory(StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
+		return this.dlqProducerFactories.get(streamsBuilderFactoryBean);
+	}
+
+	public void addDlqProducerFactory(StreamsBuilderFactoryBean streamsBuilderFactoryBean,
+									ProducerFactory<byte[], byte[]> producerFactory) {
+		List<ProducerFactory<byte[], byte[]>> producerFactories = this.dlqProducerFactories.get(streamsBuilderFactoryBean);
+		if (CollectionUtils.isEmpty(producerFactories)) {
+			producerFactories = new ArrayList<>();
+			this.dlqProducerFactories.put(streamsBuilderFactoryBean, producerFactories);
+		}
+		producerFactories.add(producerFactory);
 	}
 }

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -50,7 +50,7 @@ public class KafkaStreamsBindingInformationCatalogue {
 
 	private final Map<KStream<?, ?>, KafkaStreamsConsumerProperties> consumerProperties = new ConcurrentHashMap<>();
 
-	private final Set<StreamsBuilderFactoryBean> streamsBuilderFactoryBeans = new HashSet<>();
+	private final Map<String, StreamsBuilderFactoryBean> streamsBuilderFactoryBeanPerBinding = new HashMap<>();
 
 	private final Map<Object, ResolvableType> outboundKStreamResolvables = new HashMap<>();
 
@@ -127,18 +127,18 @@ public class KafkaStreamsBindingInformationCatalogue {
 		}
 	}
 
-	/**
-	 * Adds a mapping for KStream -> {@link StreamsBuilderFactoryBean}.
-	 * @param streamsBuilderFactoryBean provides the {@link StreamsBuilderFactoryBean}
-	 * mapped to the KStream
-	 */
-	void addStreamBuilderFactory(StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
-		this.streamsBuilderFactoryBeans.add(streamsBuilderFactoryBean);
+	Set<StreamsBuilderFactoryBean> getStreamsBuilderFactoryBeans() {
+		return new HashSet<>(this.streamsBuilderFactoryBeanPerBinding.values());
 	}
 
-	Set<StreamsBuilderFactoryBean> getStreamsBuilderFactoryBeans() {
-		return this.streamsBuilderFactoryBeans;
+	void addStreamBuilderFactoryPerBinding(String binding, StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
+		this.streamsBuilderFactoryBeanPerBinding.put(binding, streamsBuilderFactoryBean);
 	}
+
+	Map<String, StreamsBuilderFactoryBean> getStreamsBuilderFactoryBeanPerBinding() {
+		return this.streamsBuilderFactoryBeanPerBinding;
+	}
+
 
 	void addOutboundKStreamResolvable(Object key, ResolvableType outboundResolvable) {
 		this.outboundKStreamResolvables.put(key, outboundResolvable);

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsRegistry.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsRegistry.java
@@ -42,7 +42,14 @@ public class KafkaStreamsRegistry {
 	private final Set<KafkaStreams> kafkaStreams = new HashSet<>();
 
 	Set<KafkaStreams> getKafkaStreams() {
-		return this.kafkaStreams;
+		Set<KafkaStreams> currentlyRunningKafkaStreams = new HashSet<>();
+		for (KafkaStreams ks : this.kafkaStreams) {
+			final StreamsBuilderFactoryBean streamsBuilderFactoryBean = streamsBuilderFactoryBeanMap.get(ks);
+			if (streamsBuilderFactoryBean.isRunning()) {
+				currentlyRunningKafkaStreams.add(ks);
+			}
+		}
+		return currentlyRunningKafkaStreams;
 	}
 
 	/**
@@ -67,7 +74,7 @@ public class KafkaStreamsRegistry {
 	public StreamsBuilderFactoryBean streamsBuilderFactoryBean(String applicationId) {
 		final Optional<StreamsBuilderFactoryBean> first = this.streamsBuilderFactoryBeanMap.values()
 				.stream()
-				.filter(streamsBuilderFactoryBean -> streamsBuilderFactoryBean
+				.filter(streamsBuilderFactoryBean -> streamsBuilderFactoryBean.isRunning() && streamsBuilderFactoryBean
 						.getStreamsConfiguration().getProperty(StreamsConfig.APPLICATION_ID_CONFIG)
 						.equals(applicationId))
 				.findFirst();

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsInteractiveQueryIntegrationTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsInteractiveQueryIntegrationTests.java
@@ -102,6 +102,7 @@ public class KafkaStreamsInteractiveQueryIntegrationTests {
 		Mockito.when(mock.getKafkaStreams()).thenReturn(mockKafkaStreams);
 		KafkaStreamsRegistry kafkaStreamsRegistry = new KafkaStreamsRegistry();
 		kafkaStreamsRegistry.registerKafkaStreams(mock);
+		Mockito.when(mock.isRunning()).thenReturn(true);
 		KafkaStreamsBinderConfigurationProperties binderConfigurationProperties =
 				new KafkaStreamsBinderConfigurationProperties(new KafkaProperties());
 		binderConfigurationProperties.getStateStoreRetry().setMaxAttempts(3);


### PR DESCRIPTION
Introduce the ability for Kafka Streams application's lifecycle
management through actuator binding endpoints. Kafka Streams
only supports STOP and START operations. PAUSE/RESUME operations
that is available in regular message channel based binders
are not available in Kafka Streams binder.

Adding tests and docs.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1038
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/850

https://stackoverflow.com/questions/60282225/why-doesnt-kstreambinder-have-a-lifecycle-for-defaultbinding