### PR TITLE
Fix destination as pattern issues in Kafka Streams

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
@@ -425,17 +425,19 @@ public abstract class AbstractKafkaStreamsBinderProcessor implements Application
 		}
 
 		KStream<?, ?> stream;
+		final Serde<?> valueSerdeToUse = StringUtils.hasText(kafkaStreamsConsumerProperties.getEventTypes()) ?
+				new Serdes.BytesSerde() : valueSerde;
+		final Consumed<?, ?> consumed = getConsumed(kafkaStreamsConsumerProperties, keySerde, valueSerdeToUse, autoOffsetReset);
+
 		if (this.kafkaStreamsExtendedBindingProperties
 				.getExtendedConsumerProperties(inboundName).isDestinationIsPattern()) {
 			final Pattern pattern = Pattern.compile(this.bindingServiceProperties.getBindingDestination(inboundName));
-			stream = streamsBuilder.stream(pattern);
+
+			stream = streamsBuilder.stream(pattern, consumed);
 		}
 		else {
 			String[] bindingTargets = StringUtils.commaDelimitedListToStringArray(
 					this.bindingServiceProperties.getBindingDestination(inboundName));
-			final Serde<?> valueSerdeToUse = StringUtils.hasText(kafkaStreamsConsumerProperties.getEventTypes()) ?
-					new Serdes.BytesSerde() : valueSerde;
-			final Consumed<?, ?> consumed = getConsumed(kafkaStreamsConsumerProperties, keySerde, valueSerdeToUse, autoOffsetReset);
 			stream = streamsBuilder.stream(Arrays.asList(bindingTargets),
 					consumed);
 		}

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderDestinationIsPatternTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderDestinationIsPatternTests.java
@@ -76,7 +76,6 @@ public class KafkaStreamsBinderDestinationIsPatternTests {
 		ConfigurableApplicationContext context = app.run("--server.port=0",
 				"--spring.cloud.stream.bindings.process-out-0.destination=out",
 				"--spring.cloud.stream.bindings.process-in-0.destination=in.*",
-				"--spring.cloud.stream.bindings.process-in-0.consumer.use-native-decoding=false",
 				"--spring.cloud.stream.kafka.streams.bindings.process-in-0.consumer.destinationIsPattern=true",
 				"--spring.cloud.stream.kafka.streams.binder.brokers="
 						+ embeddedKafka.getBrokersAsString());


### PR DESCRIPTION
When destination-is-pattern property is enabled and native deserialization
is used, then Kafka Streams binder does not use the correct Serde types.
Fixing this issue by providing the proper Serdes to the StreamsBuilder.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1051