### PR TITLE
GH-1081 Suspicious multiplication of ScheduledExecutorService

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
@@ -65,8 +65,6 @@ import org.springframework.util.ObjectUtils;
 public class KafkaBinderMetrics
         implements MeterBinder, ApplicationListener<BindingCreatedEvent> {
 
-    private static final int SCHEDULER_SHUTDOWN_TIMEOUT_SEC = 1;
-
     private static final int DEFAULT_TIMEOUT = 5;
 
     private static final int DELAY_BETWEEN_TASK_EXECUTION = 60;
@@ -126,15 +124,6 @@ public class KafkaBinderMetrics
         if (this.scheduler != null) {
             LOG.info("Try to shutdown the old scheduler with " + ((ScheduledThreadPoolExecutor) scheduler).getPoolSize() + " threads");
             this.scheduler.shutdown();
-            boolean terminationResult;
-            try {
-                terminationResult = this.scheduler.awaitTermination(SCHEDULER_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                throw new IllegalStateException("The previous scheduler can't be terminated properly", ex);
-            }
-            if (!terminationResult) {
-                throw new IllegalStateException("The previous scheduler can't be terminated in " + SCHEDULER_SHUTDOWN_TIMEOUT_SEC + " seconds");
-            }
         }
 
         this.scheduler = Executors.newScheduledThreadPool(this.binder.getTopicsInUse().size());


### PR DESCRIPTION
GH-1081 Suspicious multiplication of ScheduledExecutorService in the method "bindTo" of class "KafkaBinderMetrics"

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1081

The wrong consequence of scheduler.shutdown() absence:
1) First of all we created the pool with 1 thread.
2) After we lost the reference on it and created the pool with 2 threads.
3) But, the first pool is not yet collected by GC and now you have 3 threads together. And so on.
Each thread does nothing, but it takes system memory and takes part in the scheduling process. After 30 topics, for example, we potentially have (30+1)*15=465 threads. It is already a serious additional load on the switching contexts and the native memory.