### PR TITLE
Fixing consumer config typo in overview.adoc

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -855,7 +855,7 @@ You cannot set the `resetOffsets` consumer property to `true` when you provide a
 If you want advanced customization of consumer and producer configuration that is used for creating `ConsumerFactory` and `ProducerFactory` in Kafka,
 you can implement the following customizers.
 
-* ConsusumerConfigCustomizer
+* ConsumerConfigCustomizer
 * ProducerConfigCustomizer
 
 Both of these interfaces provide a way to configure the config map used for consumer and producer properties.


### PR DESCRIPTION
ConsumerConfigCustomizer is the correct name of the interface.