### PR TITLE
Honoring auto startup in Kafka Streams binder

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1758,6 +1758,30 @@ For instance, if we want to change the header key on this binding to `my_event` 
 
 `spring.cloud.stream.kafka.streams.bindings.process-in-0.consumer.eventTypeHeaderKey=my_event`.
 
+=== Manually starting Kafka Streams processors
+
+Spring Cloud Stream Kafka Streasm binder offers an abstraction called `StreasmBuilderFactoryManager` on top of the `StreamsBuilderFactoryBean` from Spring for Apache Kafka.
+This manager API is used for controlling the multiple `StreamsBuilderFactoryBean` per processor in a binder based application.
+Therefore, when using the binder, if you manually want to control the auto starting of the various `StreamsBuilderFactoryBean` objects in the application, you need to use `StreamsBuilderFactoryManager`.
+You can use the property `spring.kafka.streams.auto-startup` and set this to `false` in order to turn off auto starting of the processors.
+Then, in the application, you can use something as below to start the processors using `StreamsBuilderFactoryManager`.
+
+```
+@Bean
+public ApplicationRunner runner(StreamsBuilderFactoryManager sbfm) {
+    return args -> {
+        sbfm.start();
+    };
+}
+```
+
+This feature is handy, when you want your application to start in the main thread and let Kafka Streams processors start separately.
+For example, when you have a large state store that needs to be restored, if the processors are started normally as is the default case, this may block your application to start.
+If you are using some sort of livenes probe mechanism, it may think that the application is down and attempt a restart.
+In order to correct this, you can set `spring.kafka.streams.auto-startup` to `false` and follow the approach above.
+
+Keep in mind that, when using the Spring Cloud Stream binder, you are not directly dealing with `StreamsBuilderFactoryBean` from Spring for Apache Kafka, rather `StreasmBuilderFactoryManager`, as the `StreamsBuilderFactoryBean` objects are internally managed by the binder.
+
 === Binding visualization and control in Kafka Streams binder
 
 Starting with version 3.1.2, Kafka Streams binder supports binding visualization and control.
@@ -1869,6 +1893,9 @@ curl -d '{"state":"STARTED"}' -H "Content-Type: application/json" -X POST http:/
 When there are multiple bindings present on a single function, invoking these operations on any of those bindings will work.
 This is because all the bindings on a single function are backed by the same `StreamsBuilderFactoryBean`.
 Therefore, for the function above, either `function-in-0` or `function-out-0` will work.
+
+NOTE: When `auto-startup` is disabled using `spring.kafa.streams.auto-startup: false`, then before using the binding controls to start or stop individual bindings, you must start the `StreamsBuilderFactoryManager`.
+See the above section for more details on this.
 
 === Tracing using Spring Cloud Sleuth
 

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1922,11 +1922,11 @@ public BiFunction<KStream<?, ?>, KTable<?, ?>, KStream<?, ?>> process3() {
 In this scenario above, if you set `spring.kafka.streams.auto-startup` to `false`, then none of the processors will auto start during the application startup.
 In that case, you have to programmatically start them as described above by calling `start()` on the underlying `StreamsBuilderFactoryManager`.
 However, if we have a use case to selectively disable only one processor, then you have to set `auto-startup` on the individual binding for that processor.
-Let us assume that we don't want our `process3` function to not auto start.
+Let us assume that we don't want our `process3` function to auto start.
 This is a `BiFunction` with two input bindings - `process3-in-0` and `process3-in-1`.
 In order to avoid auto start for this processor, you can pick any of these input bindings and set `auto-startup` on them.
 It does not matter which binding you pick; if you wish, you can set `auto-startup` to `false` on both of them, but one will be sufficient.
-This is because, both of these bindings share the same `StreamsBuilderFactoryBean` behind the scenes by the binder.
+Because they share the same factory bean, you don't have to set autoStartup to false on both bindings, but it probably makes sense to do so, for clarity.
 
 Here is the Spring Cloud Stream property that you can use to disable auto startup for this processor.
 
@@ -1959,8 +1959,9 @@ public ApplicationRunner runner() {
         endpoint.changeState("process3-in-0", State.STARTED);
     };
 }
-
 ```
+
+See https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream.html#binding_visualization_control[this section] from the reference docs for more details on this mechanism.
 
 NOTE: When controlling the bindings by disabling `auto-startup` as described in this section, please note that this is only available for consumer bindings.
 In other words, if you use the producer binding, `process3-out-0`, that does not have any effect in terms of disabling the auto starting of the processor, although this producer binding uses the same `StreamsBuilderFactoryBean` as the consumer bindings.

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1758,30 +1758,6 @@ For instance, if we want to change the header key on this binding to `my_event` 
 
 `spring.cloud.stream.kafka.streams.bindings.process-in-0.consumer.eventTypeHeaderKey=my_event`.
 
-=== Manually starting Kafka Streams processors
-
-Spring Cloud Stream Kafka Streasm binder offers an abstraction called `StreasmBuilderFactoryManager` on top of the `StreamsBuilderFactoryBean` from Spring for Apache Kafka.
-This manager API is used for controlling the multiple `StreamsBuilderFactoryBean` per processor in a binder based application.
-Therefore, when using the binder, if you manually want to control the auto starting of the various `StreamsBuilderFactoryBean` objects in the application, you need to use `StreamsBuilderFactoryManager`.
-You can use the property `spring.kafka.streams.auto-startup` and set this to `false` in order to turn off auto starting of the processors.
-Then, in the application, you can use something as below to start the processors using `StreamsBuilderFactoryManager`.
-
-```
-@Bean
-public ApplicationRunner runner(StreamsBuilderFactoryManager sbfm) {
-    return args -> {
-        sbfm.start();
-    };
-}
-```
-
-This feature is handy, when you want your application to start in the main thread and let Kafka Streams processors start separately.
-For example, when you have a large state store that needs to be restored, if the processors are started normally as is the default case, this may block your application to start.
-If you are using some sort of livenes probe mechanism, it may think that the application is down and attempt a restart.
-In order to correct this, you can set `spring.kafka.streams.auto-startup` to `false` and follow the approach above.
-
-Keep in mind that, when using the Spring Cloud Stream binder, you are not directly dealing with `StreamsBuilderFactoryBean` from Spring for Apache Kafka, rather `StreasmBuilderFactoryManager`, as the `StreamsBuilderFactoryBean` objects are internally managed by the binder.
-
 === Binding visualization and control in Kafka Streams binder
 
 Starting with version 3.1.2, Kafka Streams binder supports binding visualization and control.
@@ -1894,8 +1870,100 @@ When there are multiple bindings present on a single function, invoking these op
 This is because all the bindings on a single function are backed by the same `StreamsBuilderFactoryBean`.
 Therefore, for the function above, either `function-in-0` or `function-out-0` will work.
 
-NOTE: When `auto-startup` is disabled using `spring.kafa.streams.auto-startup: false`, then before using the binding controls to start or stop individual bindings, you must start the `StreamsBuilderFactoryManager`.
-See the above section for more details on this.
+=== Manually starting Kafka Streams processors
+
+Spring Cloud Stream Kafka Streams binder offers an abstraction called `StreamsBuilderFactoryManager` on top of the `StreamsBuilderFactoryBean` from Spring for Apache Kafka.
+This manager API is used for controlling the multiple `StreamsBuilderFactoryBean` per processor in a binder based application.
+Therefore, when using the binder, if you manually want to control the auto starting of the various `StreamsBuilderFactoryBean` objects in the application, you need to use `StreamsBuilderFactoryManager`.
+You can use the property `spring.kafka.streams.auto-startup` and set this to `false` in order to turn off auto starting of the processors.
+Then, in the application, you can use something as below to start the processors using `StreamsBuilderFactoryManager`.
+
+```
+@Bean
+public ApplicationRunner runner(StreamsBuilderFactoryManager sbfm) {
+    return args -> {
+        sbfm.start();
+    };
+}
+```
+
+This feature is handy, when you want your application to start in the main thread and let Kafka Streams processors start separately.
+For example, when you have a large state store that needs to be restored, if the processors are started normally as is the default case, this may block your application to start.
+If you are using some sort of liveness probe mechanism (for example on Kubernetes), it may think that the application is down and attempt a restart.
+In order to correct this, you can set `spring.kafka.streams.auto-startup` to `false` and follow the approach above.
+
+Keep in mind that, when using the Spring Cloud Stream binder, you are not directly dealing with `StreamsBuilderFactoryBean` from Spring for Apache Kafka, rather `StreamsBuilderFactoryManager`, as the `StreamsBuilderFactoryBean` objects are internally managed by the binder.
+
+=== Manually starting Kafka Streams processors selectively
+
+While the approach laid out above will unconditionally apply auto start `false` to all the Kafka Streams processors in the application through `StreamsBuilderFactoryManager`, it is often desirable that only individually selected Kafka Streams processors are not auto started.
+For instance, let us assume that you have three different functions (processors) in your application and for one of the processors, you do not want to start it as part of the application startup.
+Here is an example of such a situation.
+
+```
+
+@Bean
+public Function<KStream<?, ?>, KStream<?, ?>> process1() {
+
+}
+
+@Bean
+public Consumer<KStream<?, ?>> process2() {
+
+}
+
+@Bean
+public BiFunction<KStream<?, ?>, KTable<?, ?>, KStream<?, ?>> process3() {
+
+}
+
+```
+
+In this scenario above, if you set `spring.kafka.streams.auto-startup` to `false`, then none of the processors will auto start during the application startup.
+In that case, you have to programmatically start them as described above by calling `start()` on the underlying `StreamsBuilderFactoryManager`.
+However, if we have a use case to selectively disable only one processor, then you have to set `auto-startup` on the individual binding for that processor.
+Let us assume that we don't want our `process3` function to not auto start.
+This is a `BiFunction` with two input bindings - `process3-in-0` and `process3-in-1`.
+In order to avoid auto start for this processor, you can pick any of these input bindings and set `auto-startup` on them.
+It does not matter which binding you pick; if you wish, you can set `auto-startup` to `false` on both of them, but one will be sufficient.
+This is because, both of these bindings share the same `StreamsBuilderFactoryBean` behind the scenes by the binder.
+
+Here is the Spring Cloud Stream property that you can use to disable auto startup for this processor.
+
+```
+spring.cloud.stream.bindings.process3-in-0.consumer.auto-startup: false
+```
+
+or
+
+```
+spring.cloud.stream.bindings.process3-in-1.consumer.auto-startup: false
+```
+
+Then, you can manually start the processor either using the REST endpoint or using the `BindingsEndpoint` API as shown below.
+For this, you need to ensure that you have the Spring Boot actuator dependency on the classpath.
+
+```
+curl -d '{"state":"STARTED"}' -H "Content-Type: application/json" -X POST http://localhost:8080/actuator/bindings/process3-in-0
+```
+
+or
+
+```
+@Autowired
+BindingsEndpoint endpoint;
+
+@Bean
+public ApplicationRunner runner() {
+    return args -> {
+        endpoint.changeState("process3-in-0", State.STARTED);
+    };
+}
+
+```
+
+NOTE: When controlling the bindings by disabling `auto-startup` as described in this section, please note that this is only available for consumer bindings.
+In other words, if you use the producer binding, `process3-out-0`, that does not have any effect in terms of disabling the auto starting of the processor, although this producer binding uses the same `StreamsBuilderFactoryBean` as the consumer bindings.
 
 === Tracing using Spring Cloud Sleuth
 

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/AbstractKafkaStreamsBinderProcessor.java
@@ -161,6 +161,8 @@ public abstract class AbstractKafkaStreamsBinderProcessor implements Application
 			//wrap the proxy created during the initial target type binding with real object (KTable)
 			kTableWrapper.wrap((KTable<Object, Object>) table);
 			this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactoryPerBinding(input, streamsBuilderFactoryBean);
+			this.kafkaStreamsBindingInformationCatalogue.addConsumerPropertiesPerSbfb(streamsBuilderFactoryBean,
+					bindingServiceProperties.getConsumerProperties(input));
 			arguments[index] = table;
 		}
 		else if (parameterType.isAssignableFrom(GlobalKTable.class)) {
@@ -173,6 +175,8 @@ public abstract class AbstractKafkaStreamsBinderProcessor implements Application
 			//wrap the proxy created during the initial target type binding with real object (KTable)
 			globalKTableWrapper.wrap((GlobalKTable<Object, Object>) table);
 			this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactoryPerBinding(input, streamsBuilderFactoryBean);
+			this.kafkaStreamsBindingInformationCatalogue.addConsumerPropertiesPerSbfb(streamsBuilderFactoryBean,
+					bindingServiceProperties.getConsumerProperties(input));
 			arguments[index] = table;
 		}
 	}

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderSupportAutoConfiguration.java
@@ -398,8 +398,8 @@ public class KafkaStreamsBinderSupportAutoConfiguration {
 			KafkaStreamsBindingInformationCatalogue catalogue,
 			KafkaStreamsRegistry kafkaStreamsRegistry,
 			@Nullable KafkaStreamsBinderMetrics kafkaStreamsBinderMetrics,
-			@Nullable KafkaStreamsMicrometerListener listener) {
-		return new StreamsBuilderFactoryManager(catalogue, kafkaStreamsRegistry, kafkaStreamsBinderMetrics, listener);
+			@Nullable KafkaStreamsMicrometerListener listener, KafkaProperties kafkaProperties) {
+		return new StreamsBuilderFactoryManager(catalogue, kafkaStreamsRegistry, kafkaStreamsBinderMetrics, listener, kafkaProperties);
 	}
 
 	@Bean

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBindingInformationCatalogue.java
@@ -54,6 +54,8 @@ public class KafkaStreamsBindingInformationCatalogue {
 
 	private final Map<String, StreamsBuilderFactoryBean> streamsBuilderFactoryBeanPerBinding = new HashMap<>();
 
+	private final Map<StreamsBuilderFactoryBean, List<ConsumerProperties>> consumerPropertiesPerSbfb = new HashMap<>();
+
 	private final Map<Object, ResolvableType> outboundKStreamResolvables = new HashMap<>();
 
 	private final Map<KStream<?, ?>, Serde<?>> keySerdeInfo = new HashMap<>();
@@ -137,10 +139,18 @@ public class KafkaStreamsBindingInformationCatalogue {
 		this.streamsBuilderFactoryBeanPerBinding.put(binding, streamsBuilderFactoryBean);
 	}
 
+	void addConsumerPropertiesPerSbfb(StreamsBuilderFactoryBean streamsBuilderFactoryBean, ConsumerProperties consumerProperties) {
+		this.consumerPropertiesPerSbfb.computeIfAbsent(streamsBuilderFactoryBean, k -> new ArrayList<>());
+		this.consumerPropertiesPerSbfb.get(streamsBuilderFactoryBean).add(consumerProperties);
+	}
+
+	public Map<StreamsBuilderFactoryBean, List<ConsumerProperties>> getConsumerPropertiesPerSbfb() {
+		return this.consumerPropertiesPerSbfb;
+	}
+
 	Map<String, StreamsBuilderFactoryBean> getStreamsBuilderFactoryBeanPerBinding() {
 		return this.streamsBuilderFactoryBeanPerBinding;
 	}
-
 
 	void addOutboundKStreamResolvable(Object key, ResolvableType outboundResolvable) {
 		this.outboundKStreamResolvables.put(key, outboundResolvable);

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsFunctionProcessor.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsFunctionProcessor.java
@@ -529,6 +529,8 @@ public class KafkaStreamsFunctionProcessor extends AbstractKafkaStreamsBinderPro
 						this.kafkaStreamsBindingInformationCatalogue.addKeySerde((KStream<?, ?>) kStreamWrapper, keySerde);
 
 						this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactoryPerBinding(input, streamsBuilderFactoryBean);
+						this.kafkaStreamsBindingInformationCatalogue.addConsumerPropertiesPerSbfb(streamsBuilderFactoryBean,
+								bindingServiceProperties.getConsumerProperties(input));
 
 						if (KStream.class.isAssignableFrom(stringResolvableTypeMap.get(input).getRawClass())) {
 							final Class<?> valueClass =

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsRegistry.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsRegistry.java
@@ -17,12 +17,12 @@
 package org.springframework.cloud.stream.binder.kafka.streams;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
@@ -37,9 +37,9 @@ import org.springframework.kafka.config.StreamsBuilderFactoryBean;
  */
 public class KafkaStreamsRegistry {
 
-	private Map<KafkaStreams, StreamsBuilderFactoryBean> streamsBuilderFactoryBeanMap = new HashMap<>();
+	private final Map<KafkaStreams, StreamsBuilderFactoryBean> streamsBuilderFactoryBeanMap = new ConcurrentHashMap<>();
 
-	private final Set<KafkaStreams> kafkaStreams = new HashSet<>();
+	private final Set<KafkaStreams> kafkaStreams = ConcurrentHashMap.newKeySet();
 
 	Set<KafkaStreams> getKafkaStreams() {
 		Set<KafkaStreams> currentlyRunningKafkaStreams = new HashSet<>();

--- a/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsStreamListenerSetupMethodOrchestrator.java
@@ -320,6 +320,9 @@ class KafkaStreamsStreamListenerSetupMethodOrchestrator extends AbstractKafkaStr
 						this.kafkaStreamsBindingInformationCatalogue.registerBindingProperties(stream, bindingProperties1);
 
 						this.kafkaStreamsBindingInformationCatalogue.addStreamBuilderFactoryPerBinding(inboundName, streamsBuilderFactoryBean);
+						this.kafkaStreamsBindingInformationCatalogue.addConsumerPropertiesPerSbfb(streamsBuilderFactoryBean,
+								bindingServiceProperties.getConsumerProperties(inboundName));
+
 						for (StreamListenerParameterAdapter streamListenerParameterAdapter : adapters) {
 							if (streamListenerParameterAdapter.supports(stream.getClass(),
 									methodParameter)) {

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
@@ -51,6 +51,7 @@ import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.DefaultBinding;
 import org.springframework.cloud.stream.binder.kafka.streams.InteractiveQueryService;
 import org.springframework.cloud.stream.binder.kafka.streams.KafkaStreamsRegistry;
+import org.springframework.cloud.stream.binder.kafka.streams.StreamsBuilderFactoryManager;
 import org.springframework.cloud.stream.binder.kafka.streams.endpoint.KafkaStreamsTopologyEndpoint;
 import org.springframework.cloud.stream.binding.InputBindingLifecycle;
 import org.springframework.cloud.stream.binding.OutputBindingLifecycle;
@@ -229,6 +230,29 @@ public class KafkaStreamsBinderWordCountFunctionTests {
 			finally {
 				pf.destroy();
 			}
+		}
+	}
+
+	@Test
+	public void testKstreamBinderAutoStartup() throws Exception {
+		SpringApplication app = new SpringApplication(WordCountProcessorApplication.class);
+		app.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = app.run(
+				"--server.port=0",
+				"--spring.jmx.enabled=false",
+				"--spring.kafka.streams.auto-startup=false",
+				"--spring.cloud.stream.bindings.process-in-0.destination=words-3",
+				"--spring.cloud.stream.bindings.process-out-0.destination=counts-3",
+				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde" +
+						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde" +
+						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.kafka.streams.binder.brokers=" + embeddedKafka.getBrokersAsString())) {
+			final StreamsBuilderFactoryManager streamsBuilderFactoryManager = context.getBean(StreamsBuilderFactoryManager.class);
+			assertThat(streamsBuilderFactoryManager.isAutoStartup()).isFalse();
+			assertThat(streamsBuilderFactoryManager.isRunning()).isFalse();
+
 		}
 	}
 

--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
@@ -252,7 +252,29 @@ public class KafkaStreamsBinderWordCountFunctionTests {
 			final StreamsBuilderFactoryManager streamsBuilderFactoryManager = context.getBean(StreamsBuilderFactoryManager.class);
 			assertThat(streamsBuilderFactoryManager.isAutoStartup()).isFalse();
 			assertThat(streamsBuilderFactoryManager.isRunning()).isFalse();
+		}
+	}
 
+	@Test
+	public void testKstreamIndividualBindingAutoStartup() throws Exception {
+		SpringApplication app = new SpringApplication(WordCountProcessorApplication.class);
+		app.setWebApplicationType(WebApplicationType.NONE);
+
+		try (ConfigurableApplicationContext context = app.run(
+				"--server.port=0",
+				"--spring.jmx.enabled=false",
+				"--spring.cloud.stream.bindings.process-in-0.destination=words-4",
+				"--spring.cloud.stream.bindings.process-in-0.consumer.auto-startup=false",
+				"--spring.cloud.stream.bindings.process-out-0.destination=counts-4",
+				"--spring.cloud.stream.kafka.streams.binder.configuration.default.key.serde" +
+						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.kafka.streams.binder.configuration.default.value.serde" +
+						"=org.apache.kafka.common.serialization.Serdes$StringSerde",
+				"--spring.cloud.stream.kafka.streams.binder.brokers=" + embeddedKafka.getBrokersAsString())) {
+			final StreamsBuilderFactoryBean streamsBuilderFactoryBean = context.getBean(StreamsBuilderFactoryBean.class);
+			assertThat(streamsBuilderFactoryBean.isRunning()).isFalse();
+			streamsBuilderFactoryBean.start();
+			assertThat(streamsBuilderFactoryBean.isRunning()).isTrue();
 		}
 	}
 


### PR DESCRIPTION
When using Kafka Streams bineder, the processors are started
unconditionally, i.e. autoStartup is always true by default.
If spring.kafka.streams.auto-startup is set, then honor that
as the auto-startup flag in the binder.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1126