### PR TITLE
Consumer/Producer prefix in Kafka Streams binder

### DIFF
--- a/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
+++ b/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsBinderWordCountFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,8 +144,8 @@ public class KafkaStreamsBinderWordCountFunctionTests {
 
 			//verify that ...binder.consumerProperties and ...binder.producerProperties work.
 			Map<String, Object> streamConfigGlobalProperties = (Map<String, Object>) context.getBean("streamConfigGlobalProperties");
-			assertThat(streamConfigGlobalProperties.get("request.timeout.ms")).isEqualTo("29000");
-			assertThat(streamConfigGlobalProperties.get("max.block.ms")).isEqualTo("90000");
+			assertThat(streamConfigGlobalProperties.get("consumer.request.timeout.ms")).isEqualTo("29000");
+			assertThat(streamConfigGlobalProperties.get("producer.max.block.ms")).isEqualTo("90000");
 
 			InputBindingLifecycle inputBindingLifecycle = context.getBean(InputBindingLifecycle.class);
 			final Collection<Binding<Object>> inputBindings = (Collection<Binding<Object>>) new DirectFieldAccessor(inputBindingLifecycle)


### PR DESCRIPTION
Kafka Streams allows the applications to separate the consumer and producer
properties using consumer/producer prefixes. Add these prefixes automatically
if they are missing from the application.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1065