### PR TITLE
GH-1135: Disable container retries when no DLQ set

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -748,11 +748,11 @@ public class KafkaMessageChannelBinder extends
 		else if (!extendedConsumerProperties.isBatchMode()
 				&& extendedConsumerProperties.getMaxAttempts() > 1
 				&& transMan == null) {
-
 			kafkaMessageDrivenChannelAdapter
 					.setRetryTemplate(buildRetryTemplate(extendedConsumerProperties));
 			kafkaMessageDrivenChannelAdapter
 					.setRecoveryCallback(errorInfrastructure.getRecoverer());
+			messageListenerContainer.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(0L, 0L)));
 		}
 		else if (!extendedConsumerProperties.isBatchMode() && transMan != null) {
 			messageListenerContainer.setAfterRollbackProcessor(new DefaultAfterRollbackProcessor<>(

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -735,24 +735,16 @@ public class KafkaMessageChannelBinder extends
 		ErrorInfrastructure errorInfrastructure = registerErrorInfrastructure(destination,
 				consumerGroup, extendedConsumerProperties);
 
-		if (extendedConsumerProperties.getMaxAttempts() > 1 && !extendedConsumerProperties.getExtension().isEnableDlq()) {
-			if (transMan != null) {
-				messageListenerContainer.setAfterRollbackProcessor(new DefaultAfterRollbackProcessor<>(new FixedBackOff(extendedConsumerProperties.getBackOffInitialInterval(),
-						extendedConsumerProperties.getMaxAttempts() - 1)));
-			}
-			else {
-				messageListenerContainer.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(extendedConsumerProperties.getBackOffInitialInterval(),
-						extendedConsumerProperties.getMaxAttempts() - 1)));
-			}
-		}
-		else if (!extendedConsumerProperties.isBatchMode()
+		if (!extendedConsumerProperties.isBatchMode()
 				&& extendedConsumerProperties.getMaxAttempts() > 1
 				&& transMan == null) {
 			kafkaMessageDrivenChannelAdapter
 					.setRetryTemplate(buildRetryTemplate(extendedConsumerProperties));
 			kafkaMessageDrivenChannelAdapter
 					.setRecoveryCallback(errorInfrastructure.getRecoverer());
-			messageListenerContainer.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(0L, 0L)));
+			if (!extendedConsumerProperties.getExtension().isEnableDlq()) {
+				messageListenerContainer.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(0L, 0L)));
+			}
 		}
 		else if (!extendedConsumerProperties.isBatchMode() && transMan != null) {
 			messageListenerContainer.setAfterRollbackProcessor(new DefaultAfterRollbackProcessor<>(

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -1333,13 +1333,9 @@ public class KafkaBinderTests extends
 		moduleOutputChannel.send(testMessage);
 
 		Thread.sleep(3000);
-		assertThat(handler.getReceivedMessages().entrySet()).hasSize(1);
-		Message<?> handledMessage = handler.getReceivedMessages().entrySet().iterator()
-				.next().getValue();
-		assertThat(handledMessage).isNotNull();
-		assertThat(
-				new String((byte[]) handledMessage.getPayload(), StandardCharsets.UTF_8))
-				.isEqualTo(testMessagePayload);
+
+		// Since we don't have a DLQ, assert that we are invoking the handler exactly the same number of times
+		// as set in consumerProperties.maxAttempt and not the default set by Spring Kafka (10 times).
 		assertThat(handler.getInvocationCount())
 				.isEqualTo(consumerProperties.getMaxAttempts());
 		binderBindUnbindLatency();


### PR DESCRIPTION
Disable default container retries when binding retries are enabled
(maxAttempts > 1) and no DLQ set.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1135