### PR TITLE
GH-1141: Streams cleanup docs

### DIFF
--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -1718,8 +1718,9 @@ spring.cloud.stream.bindings.enrichOrder-out-0.binder=kafka1 #kstream
 
 === State Cleanup
 
-By default, the `Kafkastreams.cleanup()` method is called when the binding is stopped.
-See https://docs.spring.io/spring-kafka/reference/html/_reference.html#_configuration[the Spring Kafka documentation].
+By default, no local state is cleaned up when the binding is stopped.
+This is the same behavior effective from Spring Kafka version 2.7.
+See https://docs.spring.io/spring-kafka/reference/html/#streams-config[Spring Kafka documentation] for more details.
 To modify this behavior simply add a single `CleanupConfig` `@Bean` (configured to clean up on start, stop, or neither) to the application context; the bean will be detected and wired into the factory bean.
 
 === Kafka Streams topology visualization


### PR DESCRIPTION
Clarify streams cleanup default in the docs.
Effective from Spring Kafka 2.7, no cleanup will be performed on shutdown.

Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1141