### PR TITLE
GH-1138: HealthIndicator Improvements

### DIFF
--- a/spring-cloud-stream-binder-kafka/pom.xml
+++ b/spring-cloud-stream-binder-kafka/pom.xml
@@ -44,6 +44,7 @@
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
+			<version>2.8.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -201,10 +201,12 @@ public class KafkaBinderHealthIndicator implements HealthIndicator, DisposableBe
 		for (AbstractMessageListenerContainer<?, ?> container : listenerContainers) {
 			Map<String, Object> containerDetails = new HashMap<>();
 			boolean isRunning = container.isRunning();
-			if (!isRunning) {
+			boolean isOk = container.isInExpectedState();
+			if (!isOk) {
 				status = Status.DOWN;
 			}
 			containerDetails.put("isRunning", isRunning);
+			containerDetails.put("isStoppedAbnormally", !isRunning && !isOk);
 			containerDetails.put("isPaused", container.isContainerPaused());
 			containerDetails.put("listenerId", container.getListenerId());
 			containerDetails.put("groupId", container.getGroupId());


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/1138

Don't report DOWN if a container is stopped normally.
This is a valid state when containers are not auto-startup or are stopped while
the app remains running.

Containers are stopped abnormally when
- a listener throws an `Error`
- a `CommonContainerStoppingErrorHandler` (or similar) is configured to stop the
  container after an error.