### PR TITLE
Fix PartitioningInterceptor CCE

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -419,8 +419,12 @@ public class KafkaMessageChannelBinder extends
 			List<ChannelInterceptor> interceptors = ((InterceptableChannel) channel)
 					.getInterceptors();
 			interceptors.forEach((interceptor) -> {
-				if (interceptor instanceof PartitioningInterceptor || interceptor instanceof DefaultPartitioningInterceptor) {
+				if (interceptor instanceof PartitioningInterceptor) {
 					((PartitioningInterceptor) interceptor)
+							.setPartitionCount(partitions.size());
+				}
+				else if (interceptor instanceof DefaultPartitioningInterceptor) {
+					((DefaultPartitioningInterceptor) interceptor)
 							.setPartitionCount(partitions.size());
 				}
 			});


### PR DESCRIPTION
The newly added DefaultPartitioningInteceptor must be explicitly
checked in order to avoid a CCE.

Related to resolving https://github.com/spring-cloud/spring-cloud-stream/issues/2245

Specifically for this: https://github.com/spring-cloud/spring-cloud-stream/issues/2245#issuecomment-977663452