### PR TITLE
Update documented version of kafka-clients

### DIFF
--- a/docs/src/main/asciidoc/overview.adoc
+++ b/docs/src/main/asciidoc/overview.adoc
@@ -40,7 +40,7 @@ The Apache Kafka Binder implementation maps each destination to an Apache Kafka 
 The consumer group maps directly to the same Apache Kafka concept.
 Partitioning also maps directly to Apache Kafka partitions as well.
 
-The binder currently uses the Apache Kafka `kafka-clients` version `2.3.1`.
+The binder currently uses the Apache Kafka `kafka-clients` version `3.1.0`.
 This client can communicate with older brokers (see the Kafka documentation), but certain features may not be available.
 For example, with versions earlier than 0.11.x.x, native headers are not supported.
 Also, 0.11.x.x does not support the `autoAddPartitions` property.


### PR DESCRIPTION
It looks like this has been incorrect for a few versions. The main branch is currently pulling in 3.1.0

https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/blob/main/pom.xml#L26