### PR TITLE
GH-1203: Clean up resources on close. Allow terminating an applicatio…

### DIFF
--- a/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
+++ b/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
@@ -16,10 +16,7 @@
 
 package org.springframework.cloud.stream.binder.kafka;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -63,7 +60,7 @@ import org.springframework.util.ObjectUtils;
  * @author Gary Russell
  */
 public class KafkaBinderMetrics
-		implements MeterBinder, ApplicationListener<BindingCreatedEvent> {
+		implements MeterBinder, ApplicationListener<BindingCreatedEvent>, AutoCloseable {
 
 	private static final int DEFAULT_TIMEOUT = 5;
 
@@ -252,4 +249,8 @@ public class KafkaBinderMetrics
 		}
 	}
 
+	@Override
+	public void close() throws Exception {
+		Optional.ofNullable(scheduler).ifPresent(ExecutorService::shutdown);
+	}
 }

--- a/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
+++ b/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
@@ -262,4 +262,10 @@ public class KafkaBinderMetricsTest {
 		return partitions;
 	}
 
+	@Test
+	public void shouldShutdownSchedulerOnClose() throws Exception {
+		metrics.bindTo(meterRegistry);
+		metrics.close();
+		assertThat(metrics.scheduler.isShutdown()).isTrue();
+	}
 }


### PR DESCRIPTION
Seems the issue in #1203 has not been identified correctly (at least partly). There still is a bug where cleanly closing your application by invoking `org.springframework.context.ConfigurableApplicationContext#close` is not possible. Other Spring resources are closed but the scheduler instantiated in `org.springframework.cloud.stream.binder.kafka.KafkaBinderMetrics#bindTo`  remains hanging and keeps the JVM process running.

This PR actually fixes that.
