### PR TITLE
Correct configuration for AckMode in the tips document

### DIFF
--- a/docs/src/main/asciidoc/tips.adoc
+++ b/docs/src/main/asciidoc/tips.adoc
@@ -403,7 +403,7 @@ public Consumer<Message<String>> myConsumer() {
 }
 ```
 
-Then you set the property `spring.cloud.stream.bindings.myConsumer-in-0.consumer.ackMode` to `MANUAL` or `MANUAL_IMMEDIATE`.
+Then you set the property `spring.cloud.stream.kafka.bindings.myConsumer-in-0.consumer.ackMode` to `MANUAL` or `MANUAL_IMMEDIATE`.
 
 === How do I override the default binding names in Spring Cloud Stream?
 


### PR DESCRIPTION
Current documentation had 'kafka' missing from the configuration path.